### PR TITLE
AB#67773: Update Activity Source forms

### DIFF
--- a/app/manager-frontend/src/components/DeleteModal.jsx
+++ b/app/manager-frontend/src/components/DeleteModal.jsx
@@ -1,30 +1,34 @@
 import {
   Button,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalFooter,
-  ModalBody,
-  ModalCloseButton,
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogBody,
 } from "@chakra-ui/react";
 import { FaTrash } from "react-icons/fa";
 
 export const DeleteModal = ({ title, body, isOpen, onClose, onDelete }) => (
-  <Modal isOpen={isOpen} onClose={onClose}>
-    <ModalOverlay />
-    <ModalContent>
-      <ModalHeader>{title}</ModalHeader>
-      <ModalCloseButton />
-      <ModalBody>{body}</ModalBody>
-      <ModalFooter>
-        <Button variant="ghost" mr={3} onClick={onClose}>
-          Cancel
-        </Button>
-        <Button leftIcon={<FaTrash />} colorScheme="red" onClick={onDelete}>
+  <AlertDialog isOpen={isOpen} onClose={onClose}>
+    <AlertDialogOverlay />
+    <AlertDialogContent>
+      <AlertDialogHeader fontSize="lg" fontWeight="bold">
+        {title}
+      </AlertDialogHeader>
+
+      <AlertDialogBody>{body}</AlertDialogBody>
+      <AlertDialogFooter>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          leftIcon={<FaTrash />}
+          colorScheme="red"
+          onClick={onDelete}
+          ml={3}
+        >
           Delete
         </Button>
-      </ModalFooter>
-    </ModalContent>
-  </Modal>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
 );

--- a/app/manager-frontend/src/components/DeleteModal.jsx
+++ b/app/manager-frontend/src/components/DeleteModal.jsx
@@ -9,7 +9,14 @@ import {
 } from "@chakra-ui/react";
 import { FaTrash } from "react-icons/fa";
 
-export const DeleteModal = ({ title, body, isOpen, onClose, onDelete }) => (
+export const DeleteModal = ({
+  title,
+  body,
+  isOpen,
+  onClose,
+  onDelete,
+  isLoading,
+}) => (
   <AlertDialog isOpen={isOpen} onClose={onClose}>
     <AlertDialogOverlay />
     <AlertDialogContent>
@@ -25,6 +32,7 @@ export const DeleteModal = ({ title, body, isOpen, onClose, onDelete }) => (
           colorScheme="red"
           onClick={onDelete}
           ml={3}
+          isLoading={isLoading}
         >
           Delete
         </Button>

--- a/app/manager-frontend/src/components/NavBar.jsx
+++ b/app/manager-frontend/src/components/NavBar.jsx
@@ -32,7 +32,7 @@ const BrandLink = () => {
   const { t } = useTranslation();
   return (
     <Link to="/">
-      <Heading p={2} size="lg">
+      <Heading p={2} size="lg" textTransform={"uppercase"} letterSpacing={1.1}>
         {t("buttons.brand")}
       </Heading>
     </Link>

--- a/app/manager-frontend/src/components/resultsmodifiers/ResultsModifiers.jsx
+++ b/app/manager-frontend/src/components/resultsmodifiers/ResultsModifiers.jsx
@@ -1,5 +1,4 @@
 import {
-  Heading,
   VStack,
   Grid,
   GridItem,

--- a/app/manager-frontend/src/components/resultsmodifiers/ResultsModifiers.jsx
+++ b/app/manager-frontend/src/components/resultsmodifiers/ResultsModifiers.jsx
@@ -14,13 +14,7 @@ import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
 import { useBackendApi } from "contexts/BackendApi";
 import { useActivitySourceResultsModifiersList } from "api/activitysources";
 import { useState } from "react";
-import {
-  FaGripVertical,
-  FaTrash,
-  FaEdit,
-  FaPlus,
-  FaInfoCircle,
-} from "react-icons/fa";
+import { FaGripVertical, FaTrash, FaEdit, FaPlus } from "react-icons/fa";
 import { ConfigureResultsModifierModal } from "./ConfigureResultsModifierModal";
 import { DeleteModal } from "components/DeleteModal";
 
@@ -86,11 +80,15 @@ export const ResultsModifiers = ({ id }) => {
       spacing={4}
       display="contents"
     >
-      <HStack p={2}>
-        <Heading size="lg">Result Modifiers</Heading>
+      <HStack p={2} spacing={4}>
+        <Text fontWeight={600} letterSpacing={0.7} fontSize={"2xl"}>
+          Result Modifiers
+        </Text>
+
         <Button
           colorScheme="green"
           leftIcon={<FaPlus />}
+          size="sm"
           onClick={onUpdateOpen}
         >
           <ConfigureResultsModifierModal
@@ -109,7 +107,6 @@ export const ResultsModifiers = ({ id }) => {
             fontSize={"sm"}
             letterSpacing={1.1}
           >
-            {" "}
             New
           </Text>
         </Button>
@@ -219,9 +216,7 @@ export const ResultsModifiers = ({ id }) => {
                                   <Button
                                     style={{ backgroundColor: "transparent" }}
                                   >
-                                    {" "}
                                     <FaEdit
-                                      color="darkslategray"
                                       onClick={() => onClickUpdate(item)}
                                     />
                                   </Button>

--- a/app/manager-frontend/src/components/resultsmodifiers/ResultsModifiers.jsx
+++ b/app/manager-frontend/src/components/resultsmodifiers/ResultsModifiers.jsx
@@ -22,6 +22,7 @@ export const ResultsModifiers = ({ id }) => {
   const { resultsmodifier, activitysource } = useBackendApi();
   const { data, mutate } = useActivitySourceResultsModifiersList(id);
   const [selected, setSelected] = useState();
+  const [isLoading, setIsLoading] = useState();
   const onDragEnd = async (result) => {
     // dropped outside the list
     if (!result.destination) {
@@ -50,10 +51,12 @@ export const ResultsModifiers = ({ id }) => {
   } = useDisclosure();
 
   const onDelete = async (id) => {
+    setIsLoading(true);
     await resultsmodifier.delete({ id: id });
     await mutate();
     setSelected(undefined);
     onDeleteClose();
+    setIsLoading(false);
   };
 
   const closeDelete = () => {
@@ -233,7 +236,8 @@ export const ResultsModifiers = ({ id }) => {
                                       onClose={closeDelete}
                                       id={selected ? selected.id : undefined}
                                       onDelete={() => onDelete(item.id)}
-                                    />{" "}
+                                      isLoading={isLoading}
+                                    />
                                     <FaTrash color="#cf222eed" />
                                   </Button>
 

--- a/app/manager-frontend/src/pages/ActivitySource/index.jsx
+++ b/app/manager-frontend/src/pages/ActivitySource/index.jsx
@@ -223,7 +223,7 @@ export const ActivitySource = ({ activitySource, action, id }) => {
         <>
           <ResultsModifiers id={id}></ResultsModifiers>
           <DeleteModal
-            title={`Delete Activity Source ?`}
+            title={`Delete Activity Source?`}
             body={
               <VStack>
                 <Text>

--- a/app/manager-frontend/src/pages/ActivitySource/index.jsx
+++ b/app/manager-frontend/src/pages/ActivitySource/index.jsx
@@ -11,7 +11,7 @@ import {
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { Form, Formik } from "formik";
-import { FaArrowRight, FaTrash, FaTimes } from "react-icons/fa";
+import { FaArrowRight, FaTrash, FaTimes, FaRegSave } from "react-icons/fa";
 import { FormikInput } from "../../components/forms/FormikInput";
 import { FormikSelect } from "../../components/forms/FormikSelect";
 import { useNavigate } from "react-router-dom";
@@ -110,14 +110,14 @@ export const ActivitySource = ({ activitySource, action, id }) => {
   };
 
   return (
-    <Container my={8} ref={scrollTarget} style={{ maxWidth: "850px" }}>
+    <Container my={8} ref={scrollTarget}>
       <VStack align="stretch" spacing={4} p={4} pb={10}>
         <Flex justify="space-between">
           {headingText}
           <Button
             leftIcon={<FaTimes />}
             variant="outline"
-            colorScheme="red"
+            colorScheme="gray"
             onClick={() => navigate("/home")}
           >
             Cancel
@@ -195,7 +195,7 @@ export const ActivitySource = ({ activitySource, action, id }) => {
                 )}
                 <HStack justify={"space-between"}>
                   <Button
-                    leftIcon={<FaArrowRight />}
+                    leftIcon={isUpdate ? <FaRegSave /> : <FaArrowRight />}
                     colorScheme="blue"
                     type="submit"
                     disabled={isSubmitting}

--- a/app/manager-frontend/src/pages/ActivitySource/index.jsx
+++ b/app/manager-frontend/src/pages/ActivitySource/index.jsx
@@ -109,21 +109,20 @@ export const ActivitySource = ({ activitySource, action, id }) => {
   };
 
   return (
-    <Container my={8} ref={scrollTarget}>
+    <Container my={8} ref={scrollTarget} style={{ maxWidth: "850px" }}>
       <VStack align="stretch" spacing={4} p={4} pb={10}>
         <Flex justify="space-between">
           {headingText}
-          {id && (
-            <Button
-              leftIcon={<FaTrash />}
-              variant="outline"
-              colorScheme="red"
-              onClick={onOpen}
-            >
-              Delete
-            </Button>
-          )}
+          <Button
+            leftIcon={<FaTimes />}
+            variant="outline"
+            colorScheme="red"
+            onClick={() => navigate("/home")}
+          >
+            Cancel
+          </Button>
         </Flex>
+
         <Formik
           onSubmit={handleSubmit}
           initialValues={
@@ -203,14 +202,16 @@ export const ActivitySource = ({ activitySource, action, id }) => {
                   >
                     {submitText}
                   </Button>
-                  <Button
-                    leftIcon={<FaTimes />}
-                    variant="outline"
-                    colorScheme="red"
-                    onClick={() => navigate("/home")}
-                  >
-                    Cancel
-                  </Button>
+                  {id && (
+                    <Button
+                      leftIcon={<FaTrash />}
+                      variant="outline"
+                      colorScheme="red"
+                      onClick={onOpen}
+                    >
+                      Delete
+                    </Button>
+                  )}
                 </HStack>
               </VStack>
             </Form>

--- a/app/manager-frontend/src/pages/ActivitySource/index.jsx
+++ b/app/manager-frontend/src/pages/ActivitySource/index.jsx
@@ -7,11 +7,12 @@ import {
   Alert,
   AlertIcon,
   useDisclosure,
-  HStack
+  HStack,
+  Text,
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { Form, Formik } from "formik";
-import { FaArrowRight, FaTrash } from "react-icons/fa";
+import { FaArrowRight, FaTrash, FaTimes } from "react-icons/fa";
 import { FormikInput } from "../../components/forms/FormikInput";
 import { FormikSelect } from "../../components/forms/FormikSelect";
 import { useNavigate } from "react-router-dom";
@@ -30,15 +31,36 @@ export const ActivitySource = ({ activitySource, action, id }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { activitysource } = useBackendApi();
   const [feedback, setFeedback] = useState();
-  const submitText = !activitySource
-    ? "Create Activity Source"
-    : "Save changes";
-  const headingText = !activitySource
-    ? "Create a new Activity Source"
-    : "Edit Activity Source";
-  const isUpdate = !activitySource
-    ? false
-    : true
+  const submitText = !activitySource ? "Create" : "Save";
+  const headingText = !activitySource ? (
+    <div>
+      <Text
+        color={"blue.500"}
+        fontWeight={600}
+        letterSpacing={1.1}
+        fontSize={"2xl"}
+        textTransform={"uppercase"}
+      >
+        Create Activity Source
+      </Text>
+    </div>
+  ) : (
+    <div style={{ display: "flex" }}>
+      <Text
+        color={"blue.500"}
+        fontWeight={600}
+        letterSpacing={1.1}
+        fontSize={"2xl"}
+        textTransform={"uppercase"}
+      >
+        Editing:
+      </Text>
+      <Text pl={1} fontWeight={600} letterSpacing={1.1} fontSize={"2xl"}>
+        {activitySource.displayName}
+      </Text>
+    </div>
+  );
+  const isUpdate = !activitySource ? false : true;
   const [scrollTarget, scrollTargetIntoView] = useScrollIntoView({
     behavior: "smooth",
   });
@@ -88,9 +110,9 @@ export const ActivitySource = ({ activitySource, action, id }) => {
 
   return (
     <Container my={8} ref={scrollTarget}>
-      <VStack w="100%" align="stretch" spacing={4} p={4} pb={10}>
+      <VStack align="stretch" spacing={4} p={4} pb={10}>
         <Flex justify="space-between">
-          <Heading>{headingText}</Heading>
+          {headingText}
           {id && (
             <Button
               leftIcon={<FaTrash />}
@@ -107,22 +129,22 @@ export const ActivitySource = ({ activitySource, action, id }) => {
           initialValues={
             activitySource
               ? {
-                DisplayName: activitySource.displayName,
-                Host: activitySource.host,
-                Type: activitySource.type,
-                ResourceId: activitySource.resourceId,
-                TargetDataSource:
-                  datasourceOptions.find(
-                    (item) => item.id === activitySource.targetDataSource
-                  )?.id ?? "",
-              }
+                  DisplayName: activitySource.displayName,
+                  Host: activitySource.host,
+                  Type: activitySource.type,
+                  ResourceId: activitySource.resourceId,
+                  TargetDataSource:
+                    datasourceOptions.find(
+                      (item) => item.id === activitySource.targetDataSource
+                    )?.id ?? "",
+                }
               : {
-                DisplayName: "",
-                Host: "",
-                Type: typeOptions[0].id,
-                ResourceId: "",
-                TargetDataSource: "",
-              }
+                  DisplayName: "",
+                  Host: "",
+                  Type: typeOptions[0].id,
+                  ResourceId: "",
+                  TargetDataSource: "",
+                }
           }
           validationSchema={validationSchema()}
         >
@@ -164,13 +186,15 @@ export const ActivitySource = ({ activitySource, action, id }) => {
                   }
                   hasEmptyDefault
                 />
-                {isUpdate ? null : <Alert status='info'>
-                  <AlertIcon />
-                  Result Modifiers can be added after an Activity Source is created.
-                </Alert>}
-                <HStack>
+                {isUpdate ? null : (
+                  <Alert status="info">
+                    <AlertIcon />
+                    Result Modifiers can be added after an Activity Source is
+                    created.
+                  </Alert>
+                )}
+                <HStack justify={"space-between"}>
                   <Button
-                    w="200px"
                     leftIcon={<FaArrowRight />}
                     colorScheme="blue"
                     type="submit"
@@ -179,20 +203,40 @@ export const ActivitySource = ({ activitySource, action, id }) => {
                   >
                     {submitText}
                   </Button>
+                  <Button
+                    leftIcon={<FaTimes />}
+                    variant="outline"
+                    colorScheme="red"
+                    onClick={() => navigate("/home")}
+                  >
+                    Cancel
+                  </Button>
                 </HStack>
               </VStack>
             </Form>
           )}
         </Formik>
       </VStack>
-      {isUpdate ? <ResultsModifiers id={id} ></ResultsModifiers> : null}
-      <DeleteModal
-        title={`Delete Activity Source ${id}`}
-        body="Are you sure you want to delete this activity source? You will not be able to reverse this"
-        isOpen={isOpen}
-        onClose={onClose}
-        onDelete={onDeleteSource}
-      />
+      {isUpdate ? (
+        <>
+          <ResultsModifiers id={id}></ResultsModifiers>
+          <DeleteModal
+            title={`Delete Activity Source ?`}
+            body={
+              <VStack>
+                <Text>
+                  Are you sure you want to delete this activity source:
+                </Text>
+                <Text fontWeight="bold">{activitySource.displayName}</Text>
+                <Text>You will not be able to reverse this!</Text>
+              </VStack>
+            }
+            isOpen={isOpen}
+            onClose={onClose}
+            onDelete={onDeleteSource}
+          />
+        </>
+      ) : null}
     </Container>
   );
 };

--- a/app/manager-frontend/src/pages/ActivitySource/index.jsx
+++ b/app/manager-frontend/src/pages/ActivitySource/index.jsx
@@ -32,7 +32,7 @@ export const ActivitySource = ({ activitySource, action, id }) => {
   const [isLoading, setIsLoading] = useState();
   const submitText = !activitySource ? "Create" : "Save";
   const headingText = !activitySource ? (
-    <div>
+    <Flex>
       <Text
         color={"blue.500"}
         fontWeight={600}
@@ -42,9 +42,9 @@ export const ActivitySource = ({ activitySource, action, id }) => {
       >
         Create Activity Source
       </Text>
-    </div>
+    </Flex>
   ) : (
-    <div style={{ display: "flex" }}>
+    <Flex>
       <Text
         color={"blue.500"}
         fontWeight={600}
@@ -57,7 +57,7 @@ export const ActivitySource = ({ activitySource, action, id }) => {
       <Text pl={1} fontWeight={600} letterSpacing={1.1} fontSize={"2xl"}>
         {activitySource.displayName}
       </Text>
-    </div>
+    </Flex>
   );
   const isUpdate = !activitySource ? false : true;
   const [scrollTarget, scrollTargetIntoView] = useScrollIntoView({

--- a/app/manager-frontend/src/pages/ActivitySource/index.jsx
+++ b/app/manager-frontend/src/pages/ActivitySource/index.jsx
@@ -31,6 +31,7 @@ export const ActivitySource = ({ activitySource, action, id }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { activitysource } = useBackendApi();
   const [feedback, setFeedback] = useState();
+  const [isLoading, setIsLoading] = useState();
   const submitText = !activitySource ? "Create" : "Save";
   const headingText = !activitySource ? (
     <div>
@@ -67,7 +68,9 @@ export const ActivitySource = ({ activitySource, action, id }) => {
 
   const navigate = useNavigate();
   const onDeleteSource = async () => {
+    setIsLoading(true);
     await activitysource.delete({ id: id });
+    setIsLoading(false);
     onClose();
     // redirect with a toast
     navigate("/", {
@@ -232,6 +235,7 @@ export const ActivitySource = ({ activitySource, action, id }) => {
                 <Text>You will not be able to reverse this!</Text>
               </VStack>
             }
+            isLoading={isLoading}
             isOpen={isOpen}
             onClose={onClose}
             onDelete={onDeleteSource}

--- a/app/manager-frontend/src/pages/ActivitySource/index.jsx
+++ b/app/manager-frontend/src/pages/ActivitySource/index.jsx
@@ -24,7 +24,6 @@ import { useScrollIntoView } from "helpers/hooks/useScrollIntoView";
 import { ResultsModifiers } from "components/resultsmodifiers/ResultsModifiers";
 
 export const ActivitySource = ({ activitySource, action, id }) => {
-  // TODO: Get this from the backend
   const typeOptions = [{ id: "RQUEST" }];
   const { data: datasourceOptions } = useDataSourceList();
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/app/manager-frontend/src/pages/ActivitySource/index.jsx
+++ b/app/manager-frontend/src/pages/ActivitySource/index.jsx
@@ -2,7 +2,6 @@ import {
   VStack,
   Flex,
   Button,
-  Heading,
   Container,
   Alert,
   AlertIcon,

--- a/app/manager-frontend/src/pages/UserHome.jsx
+++ b/app/manager-frontend/src/pages/UserHome.jsx
@@ -18,7 +18,7 @@ import { useState } from "react";
 import { useBackendApi } from "contexts/BackendApi";
 import { DeleteModal } from "components/DeleteModal";
 import { useNavigate } from "react-router-dom";
-import { FaPlus, FaSearch, FaInfo, FaInfoCircle } from "react-icons/fa";
+import { FaPlus, FaSearch, FaInfoCircle } from "react-icons/fa";
 
 export const UserHome = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/app/manager-frontend/src/pages/UserHome.jsx
+++ b/app/manager-frontend/src/pages/UserHome.jsx
@@ -9,7 +9,7 @@ import {
   InputGroup,
   InputLeftElement,
   Stack,
-  Box
+  Box,
 } from "@chakra-ui/react";
 import { useSortingAndFiltering } from "helpers/hooks/useSortingAndFiltering";
 import { useActivitySourceList } from "api/activitysources";
@@ -23,6 +23,7 @@ import { FaPlus, FaSearch, FaInfo, FaInfoCircle } from "react-icons/fa";
 export const UserHome = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [selectedActivitySource, setSelectedActivitySource] = useState();
+  const [isLoading, setIsLoading] = useState();
   const { activitysource } = useBackendApi();
   const { data, mutate } = useActivitySourceList();
   const navigate = useNavigate();
@@ -36,51 +37,60 @@ export const UserHome = () => {
   } = useSortingAndFiltering(data, "displayName", {
     initialSort: {
       key: "displayName",
-    }, sorters: {
-      "displayName": {
+    },
+    sorters: {
+      displayName: {
         sorter: (asc) => (a, b) =>
-          asc ? a.localeCompare(b) : b.localeCompare(a)
+          asc ? a.localeCompare(b) : b.localeCompare(a),
       },
     },
   });
 
   const onDeleteSource = async () => {
+    setIsLoading(true);
     await activitysource.delete({ id: selectedActivitySource.id });
     await mutate();
     onClose();
+    setIsLoading(false);
   };
   const onClickDelete = (activitySource) => {
     setSelectedActivitySource(activitySource);
     onOpen();
   };
   return (
-    <Stack px={8} w="100%" spacing={4} p={4} alignItems='center'>
-      {data.length > 0 ?
-        <Stack w="100%" spacing={4} >
-          <HStack maxW={'800'}
-            w={'100%'}
-            alignSelf={'center'}
-            borderRadius={'10px'}
+    <Stack px={8} w="100%" spacing={4} p={4} alignItems="center">
+      {data.length > 0 ? (
+        <Stack w="100%" spacing={4}>
+          <HStack
+            maxW={"800"}
+            w={"100%"}
+            alignSelf={"center"}
+            borderRadius={"10px"}
           >
             <InputGroup>
               <InputLeftElement
-                pointerEvents='none'
-                children={<FaSearch color='gray.300' />}
+                pointerEvents="none"
+                children={<FaSearch color="gray.300" />}
               />
-              <Input size={'md'}
+              <Input
+                size={"md"}
                 placeholder="Search Activity Sources"
                 onChange={(e) => setFilter(e.target.value)}
               />
             </InputGroup>
             <Button
-              onClick={() => navigate('/activitysources/new')}
-              colorScheme='green'
+              onClick={() => navigate("/activitysources/new")}
+              colorScheme="green"
               leftIcon={<FaPlus />}
             >
-              <Text textTransform={'uppercase'}
+              <Text
+                textTransform={"uppercase"}
                 fontWeight={700}
-                fontSize={'sm'}
-                letterSpacing={1.1}> New</Text>
+                fontSize={"sm"}
+                letterSpacing={1.1}
+              >
+                New
+              </Text>
             </Button>
           </HStack>
 
@@ -95,30 +105,37 @@ export const UserHome = () => {
                 collectionId={item.resourceId}
               />
             </>
-          ))
-          }
-        </Stack> :
+          ))}
+        </Stack>
+      ) : (
         <div>
           <Box textAlign="center" py={10} px={6}>
-            <FaInfoCircle fontSize={'2em'} color='dodgerblue' style={{ display: 'inline' }} />
+            <FaInfoCircle
+              fontSize={"2em"}
+              color="dodgerblue"
+              style={{ display: "inline" }}
+            />
             <Heading as="h2" size="xl" mb={2}>
               No Activity Sources found.
             </Heading>
             <Button
-              onClick={() => navigate('/activitysources/new')}
-              colorScheme={'green'}
+              onClick={() => navigate("/activitysources/new")}
+              colorScheme={"green"}
               leftIcon={<FaPlus />}
-              width={'225'}
+              width={"225"}
             >
-              <Text textTransform={'uppercase'}
+              <Text
+                textTransform={"uppercase"}
                 fontWeight={700}
-                fontSize={'sm'}
-                letterSpacing={1.1}> Create Activity Source</Text>
+                fontSize={"sm"}
+                letterSpacing={1.1}
+              >
+                Create Activity Source
+              </Text>
             </Button>
           </Box>
-
         </div>
-      }
+      )}
       <DeleteModal
         title={`Delete Activity Source?`}
         body={
@@ -131,7 +148,8 @@ export const UserHome = () => {
         isOpen={isOpen}
         onClose={onClose}
         onDelete={onDeleteSource}
+        isLoading={isLoading}
       />
-    </Stack >
+    </Stack>
   );
 };

--- a/app/manager-frontend/src/themes/theme.js
+++ b/app/manager-frontend/src/themes/theme.js
@@ -17,7 +17,7 @@ export const theme = extendTheme({
     },
     Container: {
       baseStyle: {
-        maxWidth: "100ch",
+        maxWidth: "850px",
       },
     },
     Heading: {


### PR DESCRIPTION
## Overview

- Change DeleteModal body text so both instances match when deleting an ActivitySource, display name instead of numeric ID, removed the close button since it already has Cancel button
  <img width="606" alt="Screenshot 2022-09-28 at 14 22 33" src="https://user-images.githubusercontent.com/75254435/192790828-d745641f-da12-49a7-b679-1bf360018c9c.png">


- Add Cancel buttons to both Edit and Create forms in case the user needs to navigate back without having to click on nav bar link
- Switch the position of the delete button to the the bottom of the form, so cancel can stay on top for both forms
- Change the headers to match, colour and display ActivitySource name in the header for Edit form
- Change button text to be shorter "Create" & "Save"
- Set default width to match the main page layout

![Screenshot 2022-10-03 at 11 21 21](https://user-images.githubusercontent.com/75254435/193555088-54564bc0-c373-4c61-b141-9b6982fc67fa.png)


![Screenshot 2022-10-03 at 11 19 28](https://user-images.githubusercontent.com/75254435/193554948-0fdaa65d-e4c3-48a2-a5de-427b594a028e.png)



## Azure Boards

- AB#77098
- AB#77148
- AB#77099
