### PR TITLE
AB#79284: Version bump workflow for manager + auto-release on PR close

### DIFF
--- a/.github/workflows/release.hutch-manager.yml
+++ b/.github/workflows/release.hutch-manager.yml
@@ -6,6 +6,13 @@ on:
       version_tag:
         description: Version tag
         required: true
+  pull_request:
+    types:
+      - closed
+    branches:
+      - release/**
+    paths:
+      - /app/HutchManager/**
   
 
 env:

--- a/.github/workflows/release.hutch-manager.yml
+++ b/.github/workflows/release.hutch-manager.yml
@@ -25,11 +25,26 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
+  get-version:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    id: get-version
+    steps:
+      - name: Get Version Tag
+        if: ${{ input.version_tag }} == ''
+        run: |
+          echo ::set-output name=VERSION_TAG::$(echo $GITHUB_REF_NAME | cut -f 2 -d /)
+      - name: Get Version Tag (manual)
+        if: ${{ input.version_tag }} != ''
+        run: |
+          echo ::set-output name=VERSION_TAG::${{ input.version_tag }}
+
   publish-manager-docker:
     runs-on: ubuntu-latest
+    needs: get-version
     env:
       APP_NAME: manager
-      VERSION_TAG: ${{ inputs.version_tag }}
+      VERSION_TAG: ${{ needs.get-version.outputs.VERSION_TAG }}
       REGISTRY: ghcr.io
     permissions:
       contents: read
@@ -63,11 +78,12 @@ jobs:
 
   publish-manager:
     runs-on: ubuntu-latest
+    needs: get-version
     env:
       CI_dotnet-project: ./app/HutchManager/HutchManager.csproj
-      CI_release-name: manager ${{ inputs.version_tag }}
+      CI_release-name: manager ${{ needs.get-version.outputs.VERSION_TAG }}
       CI_client-package: manager-frontend
-      CI_migrations-name: manager-migrations-${{ inputs.version_tag }}
+      CI_migrations-name: manager-migrations-${{ needs.get-version.outputs.VERSION_TAG }}
     permissions:
       contents: write
     steps:
@@ -103,7 +119,7 @@ jobs:
           ${{ env.CI_dotnet-project }}
           -c ${{ env.CI_build-config }}
           -o ${{ env.CI_publish-dir }}
-          /p:Version=${{ inputs.version_tag }}
+          /p:Version=${{ needs.get-version.outputs.VERSION_TAG }}
           /p:GitHash=${{ github.sha }}
 
       # TODO: binaries for db migrations during deployment?

--- a/.github/workflows/version.hutch-manager.yml
+++ b/.github/workflows/version.hutch-manager.yml
@@ -49,8 +49,22 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.30.0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.CI_node-version }}
+          cache: pnpm
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.CI_dotnet-version }}
       - name: Bump Version
-        # Todo: bump version action
+        run: >- 
+          pnpm dlx dotnet-bump
+          ${{ needs.get-version.outputs.VERSION_TAG }}
+          --no-commit 
+          app/HutchManager/HutchManager.csproj
       - name: Add & Commit
         uses: EndBug/add-and-commit@v9.1.0
         with:

--- a/.github/workflows/version.hutch-manager.yml
+++ b/.github/workflows/version.hutch-manager.yml
@@ -68,6 +68,4 @@ jobs:
       - name: Add & Commit
         uses: EndBug/add-and-commit@v9.1.0
         with:
-          add: # files altered by version bumping
-          cwd: # directory where files change
           message: bumped version to ${{ needs.get-version.outputs.VERSION_TAG }}

--- a/.github/workflows/version.hutch-manager.yml
+++ b/.github/workflows/version.hutch-manager.yml
@@ -38,3 +38,22 @@ jobs:
         if: ${{ input.version_tag }} != ''
         run: |
           echo ::set-output name=VERSION_TAG::${{ input.version_tag }}
+
+  bump-version:
+    needs: get-version
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Bump Version
+        # Todo: bump version action
+      - name: Add & Commit
+        uses: EndBug/add-and-commit@v9.1.0
+        with:
+          add: # files altered by version bumping
+          cwd: # directory where files change
+          message: bumped version to ${{ needs.get-version.outputs.VERSION_TAG }}

--- a/.github/workflows/version.hutch-manager.yml
+++ b/.github/workflows/version.hutch-manager.yml
@@ -1,0 +1,40 @@
+name: Bump Manager Version
+
+on:
+  workflow_dispatch: # manual trigger
+    inputs:
+      version_tag:
+        description: Version tag
+        required: true
+  pull_request:
+    types:
+      - opened
+    branches:
+      - release/**
+    paths:
+      - /app/HutchManager/**
+  
+
+env:
+  CI_build-config: release
+  CI_dotnet-version: 6.0.x
+  CI_node-version: "16"
+  CI_publish-dir: publish
+
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  get-version:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    id: get-version
+    steps:
+      - name: Get Version Tag
+        if: ${{ input.version_tag }} == ''
+        run: |
+          echo ::set-output name=VERSION_TAG::$(echo $GITHUB_REF_NAME | cut -f 2 -d /)
+      - name: Get Version Tag (manual)
+        if: ${{ input.version_tag }} != ''
+        run: |
+          echo ::set-output name=VERSION_TAG::${{ input.version_tag }}

--- a/app/HutchManager/HutchManager.csproj
+++ b/app/HutchManager/HutchManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.1.2</Version>
+    <Version>1.0.0-alpha.1</Version>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/app/HutchManager/HutchManager.csproj
+++ b/app/HutchManager/HutchManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.0.0-alpha.1</Version>
+    <Version>0.1.2</Version>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Overview

- Added PR close trigger to manager release workflow.
- Created workflow to bump the version number of the manager when a release PR is opened.

## Azure Boards

- AB#79285
- AB#79286
- AB#79287
