### PR TITLE
AB#79982: Manager homepage

### DIFF
--- a/app/manager-frontend/src/components/NavBar.jsx
+++ b/app/manager-frontend/src/components/NavBar.jsx
@@ -22,7 +22,7 @@ import {
   FaUserCircle,
   FaUserPlus,
 } from "react-icons/fa";
-import { Link, useNavigate, useLocation } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { LoadingModal } from "./LoadingModal";
 import Flags from "country-flag-icons/react/3x2";
 import { hasFlag } from "country-flag-icons";
@@ -159,27 +159,7 @@ const LanguageMenu = () => {
   );
 };
 
-const DefaultNav = () => {
-  // default Nav bar item
-  return (
-    <>
-      <BrandLink />
-      <HStack spacing={0} flexGrow={1} justify="end">
-        {/* TODO: more links */}
-        <UserMenu />
-      </HStack>
-    </>
-  );
-};
-
 export const NavBar = () => {
-  const location = useLocation();
-  //hide or unhide default nav bar item based on the criteria below
-  const isDefaultNavHidden =
-    location.pathname.startsWith("/account/") &&
-    !location.pathname.startsWith("/account/password/")
-      ? true
-      : false;
   const { user } = useUser();
 
   return (
@@ -189,9 +169,12 @@ export const NavBar = () => {
       zIndex={1000}
       bgGradient="radial(circle 400px at top left, cyan.600, blue.900)"
       color="white"
-      h={isDefaultNavHidden && 5} // display solid line with if default nav bar item is hidden
     >
-      {!isDefaultNavHidden && <DefaultNav />}
+      <BrandLink />
+      <HStack spacing={0} flexGrow={1} justify="end">
+        {/* TODO: more links */}
+        <UserMenu />
+      </HStack>
     </Flex>
   );
 };

--- a/app/manager-frontend/src/components/NavBar.jsx
+++ b/app/manager-frontend/src/components/NavBar.jsx
@@ -22,12 +22,12 @@ import {
   FaUserCircle,
   FaUserPlus,
 } from "react-icons/fa";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import { LoadingModal } from "./LoadingModal";
 import Flags from "country-flag-icons/react/3x2";
 import { hasFlag } from "country-flag-icons";
 import { forwardRef } from "react";
-import { HutchLogo } from "./Logo"; //default logoMaxWidth is 50px, default logoFillColor is #fff, logoColor true/false (true generates colored logo)
+import { HutchLogo } from "./Logo";
 
 const BrandLink = () => {
   return (
@@ -159,7 +159,27 @@ const LanguageMenu = () => {
   );
 };
 
+const DefaultNav = () => {
+  // default Nav bar item
+  return (
+    <>
+      <BrandLink />
+      <HStack spacing={0} flexGrow={1} justify="end">
+        {/* TODO: more links */}
+        <UserMenu />
+      </HStack>
+    </>
+  );
+};
+
 export const NavBar = () => {
+  const location = useLocation();
+  //hide or unhide default nav bar item based on the criteria below
+  const isDefaultNavHidden =
+    location.pathname.startsWith("/account/") &&
+    !location.pathname.startsWith("/account/password/")
+      ? true
+      : false;
   const { user } = useUser();
 
   return (
@@ -169,12 +189,9 @@ export const NavBar = () => {
       zIndex={1000}
       bgGradient="radial(circle 400px at top left, cyan.600, blue.900)"
       color="white"
+      h={isDefaultNavHidden && 5} // display solid line with if default nav bar item is hidden
     >
-      <BrandLink />
-      <HStack spacing={0} flexGrow={1} justify="end">
-        {/* TODO: more links */}
-        <UserMenu />
-      </HStack>
+      {!isDefaultNavHidden && <DefaultNav />}
     </Flex>
   );
 };

--- a/app/manager-frontend/src/pages/account/Login.jsx
+++ b/app/manager-frontend/src/pages/account/Login.jsx
@@ -2,6 +2,7 @@ import {
   Alert,
   AlertIcon,
   Button,
+  Center,
   Container,
   Heading,
   HStack,
@@ -9,7 +10,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { Link as RouterLink, useLocation, useNavigate } from "react-router-dom";
-import { FaSignInAlt } from "react-icons/fa";
+import { FaSignInAlt, FaUserPlus } from "react-icons/fa";
 import { PasswordField } from "components/forms/PasswordField";
 import { Form, Formik } from "formik";
 import { useTranslation } from "react-i18next";
@@ -20,6 +21,7 @@ import { ResendConfirmAlert } from "components/account/ResendConfirmAlert";
 import { useBackendApi } from "contexts/BackendApi";
 import { EmailField } from "components/forms/EmailField";
 import { useScrollIntoView } from "helpers/hooks/useScrollIntoView";
+import { HutchLogo } from "components/Logo";
 
 const validationSchema = (t) =>
   object().shape({
@@ -91,8 +93,16 @@ export const Login = () => {
   };
 
   return (
-    <Container ref={scrollTarget} key={key} my={8}>
+    <Container maxWidth="md" ref={scrollTarget} key={key} my={8}>
       <VStack align="stretch" spacing={4}>
+        <Center>
+          <HutchLogo
+            logoColor={true}
+            logoMaxWidth="170px"
+            logoFillColor="#000"
+          />
+        </Center>
+
         <Heading as="h2" size="lg">
           {t("login.heading")}
         </Heading>
@@ -139,9 +149,15 @@ export const Login = () => {
                   >
                     {t("buttons.login")}
                   </Button>
-                  <Link as={RouterLink} to="/account/register">
-                    {t("login.links.register")}
-                  </Link>
+                  <Button
+                    colorScheme="blue"
+                    variant="link"
+                    leftIcon={<FaUserPlus />}
+                  >
+                    <Link as={RouterLink} to="/account/register">
+                      {t("login.links.register")}
+                    </Link>
+                  </Button>
                 </HStack>
               </VStack>
             </Form>

--- a/app/manager-frontend/src/pages/account/Register.jsx
+++ b/app/manager-frontend/src/pages/account/Register.jsx
@@ -2,6 +2,7 @@ import {
   Alert,
   AlertIcon,
   Button,
+  Center,
   Container,
   Heading,
   HStack,
@@ -10,7 +11,7 @@ import {
 } from "@chakra-ui/react";
 import { Form, Formik } from "formik";
 import { Link as RouterLink, useLocation } from "react-router-dom";
-import { FaUserPlus } from "react-icons/fa";
+import { FaUserPlus, FaSignInAlt } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
 import { object, string } from "yup";
 import { useResetState } from "helpers/hooks/useResetState";
@@ -26,6 +27,7 @@ import {
   validationSchema as pwSchema,
 } from "components/forms/PasswordField";
 import { useScrollIntoView } from "helpers/hooks/useScrollIntoView";
+import { HutchLogo } from "components/Logo";
 
 export const validationSchema = (t) =>
   object().shape({
@@ -96,8 +98,15 @@ export const Register = () => {
   };
 
   return (
-    <Container ref={scrollTarget} key={key} my={8}>
+    <Container maxWidth="md" ref={scrollTarget} key={key} my={8}>
       <VStack align="stretch" spacing={4}>
+        <Center>
+          <HutchLogo
+            logoColor={true}
+            logoMaxWidth="170px"
+            logoFillColor="#000"
+          />
+        </Center>
         <Heading as="h2" size="lg">
           {t("register.heading")}
         </Heading>
@@ -139,7 +148,7 @@ export const Register = () => {
 
                 <HStack justify="space-between">
                   <Button
-                    w="200px"
+                    w="150px"
                     colorScheme="blue"
                     leftIcon={<FaUserPlus />}
                     type="submit"
@@ -149,9 +158,15 @@ export const Register = () => {
                     {t("buttons.register")}
                   </Button>
 
-                  <Link as={RouterLink} to="/account/login">
-                    {t("register.links.login")}
-                  </Link>
+                  <Button
+                    colorScheme="blue"
+                    variant="link"
+                    leftIcon={<FaSignInAlt />}
+                  >
+                    <Link as={RouterLink} to="/account/login">
+                      {t("register.links.login")}
+                    </Link>
+                  </Button>
                 </HStack>
               </VStack>
             </Form>

--- a/app/manager-frontend/src/pages/account/RequestPasswordReset.jsx
+++ b/app/manager-frontend/src/pages/account/RequestPasswordReset.jsx
@@ -2,6 +2,7 @@ import {
   Alert,
   AlertIcon,
   Button,
+  Center,
   Container,
   Heading,
   VStack,
@@ -18,6 +19,7 @@ import {
 } from "components/forms/EmailField";
 import { object } from "yup";
 import { useScrollIntoView } from "helpers/hooks/useScrollIntoView";
+import { HutchLogo } from "components/Logo";
 
 const validationSchema = (t) => object().shape(emailSchema(t));
 
@@ -86,8 +88,15 @@ export const RequestPasswordReset = () => {
   };
 
   return (
-    <Container ref={scrollTarget} key={key} my={8}>
+    <Container maxWidth="md" ref={scrollTarget} key={key} my={8}>
       <VStack align="stretch" spacing={4}>
+        <Center>
+          <HutchLogo
+            logoColor={true}
+            logoMaxWidth="170px"
+            logoFillColor="#000"
+          />
+        </Center>
         <Heading as="h2" size="lg">
           {t("requestPasswordReset.heading")}
         </Heading>

--- a/app/manager-frontend/src/pages/account/ResetPassword.jsx
+++ b/app/manager-frontend/src/pages/account/ResetPassword.jsx
@@ -2,6 +2,7 @@ import {
   Alert,
   AlertIcon,
   Button,
+  Center,
   Container,
   Heading,
   Text,
@@ -23,6 +24,7 @@ import {
   validationSchema as pwSchema,
 } from "components/forms/PasswordField";
 import { useScrollIntoView } from "helpers/hooks/useScrollIntoView";
+import { HutchLogo } from "components/Logo";
 
 const validationSchema = (t) => object().shape(pwSchema(t));
 
@@ -150,8 +152,15 @@ export const ResetPassword = () => {
   };
 
   return (
-    <Container ref={scrollTarget} key={key} my={8}>
+    <Container maxWidth="md" ref={scrollTarget} key={key} my={8}>
       <VStack align="stretch" spacing={4}>
+        <Center>
+          <HutchLogo
+            logoColor={true}
+            logoMaxWidth="170px"
+            logoFillColor="#000"
+          />
+        </Center>
         <Heading as="h2" size="lg">
           {t("resetPassword.heading")}
         </Heading>

--- a/app/manager-frontend/src/routes/Root.jsx
+++ b/app/manager-frontend/src/routes/Root.jsx
@@ -17,7 +17,7 @@ const IndexRedirect = () => {
   const { user } = useUser();
   const navigate = useNavigate();
   useEffect(() => {
-    const targetPath = user ? "/home" : "/about";
+    const targetPath = user ? "/home" : "/account/login";
     navigate(targetPath, { replace: true });
   }, [user]);
 


### PR DESCRIPTION
## Overview

- Add the color Hutch logo to the login, registration and password reset pages.
**Login page**
![image](https://user-images.githubusercontent.com/25617324/197800188-f97906cc-1734-4773-8729-a4c5825c4596.png)

**Registration page**
![image](https://user-images.githubusercontent.com/25617324/197800880-49b2de98-0a92-415f-87c0-b8adf1694a92.png)

**Password reset page**
![image](https://user-images.githubusercontent.com/25617324/197801004-429c792a-44a6-4f8c-bbd2-6f9e6f0cee0d.png)

- Update the index route
- Display navbar items (collectively) based on pathname. For example, hide nav bar items in **login** page but display when users log in.

## Azure Boards

- AB#79993
- AB#79994
- AB#79995

## Notes

