### PR TITLE
AB#83751: SMTP support

### DIFF
--- a/app/HutchManager/Config/EmailSenderOptions.cs
+++ b/app/HutchManager/Config/EmailSenderOptions.cs
@@ -26,8 +26,8 @@ namespace HutchManager.Config
   public record SmtpOptions : BaseEmailSenderOptions
   {
     public string SmtpHost { get; init; } = string.Empty;
-    public int SmtpPort { get; init; } = 0;
-    public int SmtpSecureSocketEnum { get; init; } = 1; // 1 - Auto
+    public int SmtpPort { get; init; }
+    public int SmtpSecureSocketEnum { get; init; }
     
     public string SmtpUsername { get; init; } = string.Empty;
     public string SmtpPassword { get; init; } = string.Empty;

--- a/app/HutchManager/Config/EmailSenderOptions.cs
+++ b/app/HutchManager/Config/EmailSenderOptions.cs
@@ -23,4 +23,15 @@ namespace HutchManager.Config
   {
     public string SendGridApiKey { get; init; } = string.Empty;
   }
+  public record SmtpOptions : BaseEmailSenderOptions
+  {
+    public string SmtpHost { get; init; } = string.Empty;
+    public int SmtpPort { get; init; } = 0;
+    public int SmtpSecureSocketEnum { get; init; } = 1; // 1 - Auto
+    
+    public string SmtpUsername { get; init; } = string.Empty;
+    public string SmtpPassword { get; init; } = string.Empty;
+
+    
+  }
 }

--- a/app/HutchManager/Extensions/ServiceCollectionExtensions.cs
+++ b/app/HutchManager/Extensions/ServiceCollectionExtensions.cs
@@ -17,8 +17,10 @@ namespace HutchManager.Extensions
       var emailProvider = c["OutboundEmail:Provider"] ?? string.Empty;
 
       var useSendGrid = emailProvider.Equals("sendgrid", StringComparison.InvariantCultureIgnoreCase);
+      var useSmtp = emailProvider.Equals("smtp", StringComparison.InvariantCultureIgnoreCase);
 
       if (useSendGrid) s.Configure<SendGridOptions>(c.GetSection("OutboundEmail"));
+      else if (useSmtp) s.Configure<SmtpOptions>(c.GetSection("OutboundEmail"));
       else s.Configure<LocalDiskEmailOptions>(c.GetSection("OutboundEmail"));
 
       s
@@ -28,6 +30,7 @@ namespace HutchManager.Extensions
               .TryAddSingleton<IActionContextAccessor, ActionContextAccessor>();
 
       if (useSendGrid) s.AddTransient<IEmailSender, SendGridEmailSender>();
+      else if (useSmtp) s.AddTransient<IEmailSender, SmtpEmailSender>();
       else s.AddTransient<IEmailSender, LocalDiskEmailSender>();
 
       return s;

--- a/app/HutchManager/HutchManager.csproj
+++ b/app/HutchManager/HutchManager.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="ClacksMiddlware" Version="2.1.0" />
     <PackageReference Include="Flurl" Version="3.0.4" />
     <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="6.1.2" />
+    <PackageReference Include="MailKit" Version="3.4.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.1" />
@@ -45,7 +46,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="MimeKit" Version="3.1.1" />
+    <PackageReference Include="MimeKit" Version="3.4.2" />
     <PackageReference Include="SendGrid" Version="9.25.2" />
   </ItemGroup>
 

--- a/app/HutchManager/Services/EmailSender/SMTPEmailSender.cs
+++ b/app/HutchManager/Services/EmailSender/SMTPEmailSender.cs
@@ -1,0 +1,80 @@
+using HutchManager.Config;
+using HutchManager.Models.Emails;
+using HutchManager.Services.Contracts;
+using HutchManager.Services.EmailServices;
+using Microsoft.Extensions.Options;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+
+namespace HutchManager.Services.EmailSender;
+
+public class SmtpEmailSender : IEmailSender
+{
+  private readonly SmtpOptions _config;
+  private readonly RazorViewService _emailViews;
+  private readonly SmtpClient _smtpClient;
+  
+  public SmtpEmailSender(
+    IOptions<SmtpOptions> options,
+    RazorViewService emailViews)
+  {
+    _config = options.Value;
+    _emailViews = emailViews;
+    _smtpClient = new SmtpClient();
+    
+  }
+
+  public async Task SendEmail<TModel>(List<EmailAddress> toAddresses, string viewName, TModel model) 
+    where TModel : class
+  {
+    var (body, viewContext) = await _emailViews.RenderToString(viewName, model);
+
+    var message = new MimeMessage();
+
+    foreach (var address in toAddresses)
+      message.To.Add(!string.IsNullOrEmpty(address.Name)
+        ? new MailboxAddress(address.Name, address.Address)
+        : MailboxAddress.Parse(address.Address));
+
+    message.From.Add(new MailboxAddress(_config.FromName, _config.FromAddress));
+    message.ReplyTo.Add(MailboxAddress.Parse(_config.ReplyToAddress));
+    message.Subject = (string?)viewContext.ViewBag.Subject ?? string.Empty;
+
+    message.Body = new TextPart(MimeKit.Text.TextFormat.Html)
+    {
+      Text = body
+    };
+
+    var secureSocketOption = new Dictionary<int, SecureSocketOptions>
+    {
+      { 0, SecureSocketOptions.None },
+      { 1, SecureSocketOptions.Auto },
+      { 2, SecureSocketOptions.SslOnConnect },
+      { 3, SecureSocketOptions.StartTls },
+      { 4, SecureSocketOptions.StartTlsWhenAvailable }
+    };
+    try
+    {
+      await _smtpClient.ConnectAsync(_config.SmtpHost, _config.SmtpPort,
+        secureSocketOption[_config.SmtpSecureSocketEnum]);
+      await _smtpClient.AuthenticateAsync(_config.SmtpUsername, _config.SmtpPassword);
+
+    }
+    catch (Exception ex)
+    {
+      throw new InvalidOperationException(ex.ToString());
+    }
+    finally
+    {
+      await _smtpClient.DisconnectAsync(true);
+      _smtpClient.Dispose();
+    }
+  }
+
+  public async Task SendEmail<TModel>(EmailAddress toAddress, string viewName, TModel model)
+    where TModel : class
+    => await SendEmail(new List<EmailAddress> { toAddress }, viewName, model);
+
+
+}

--- a/app/HutchManager/Services/EmailSender/SMTPEmailSender.cs
+++ b/app/HutchManager/Services/EmailSender/SMTPEmailSender.cs
@@ -59,6 +59,7 @@ public class SmtpEmailSender : IEmailSender
       await _smtpClient.ConnectAsync(_config.SmtpHost, _config.SmtpPort,
         secureSocketOption[_config.SmtpSecureSocketEnum]);
       await _smtpClient.AuthenticateAsync(_config.SmtpUsername, _config.SmtpPassword);
+      await _smtpClient.SendAsync(message);
 
     }
     catch (Exception ex)

--- a/app/HutchManager/Services/EmailSender/SMTPEmailSender.cs
+++ b/app/HutchManager/Services/EmailSender/SMTPEmailSender.cs
@@ -13,16 +13,18 @@ public class SmtpEmailSender : IEmailSender
 {
   private readonly SmtpOptions _config;
   private readonly RazorViewService _emailViews;
+  private readonly ILogger<SmtpEmailSender> _logger;
   private readonly SmtpClient _smtpClient;
   
   public SmtpEmailSender(
     IOptions<SmtpOptions> options,
-    RazorViewService emailViews)
+    RazorViewService emailViews,
+    ILogger<SmtpEmailSender> logger )
   {
     _config = options.Value;
     _emailViews = emailViews;
+    _logger = logger;
     _smtpClient = new SmtpClient();
-    
   }
 
   public async Task SendEmail<TModel>(List<EmailAddress> toAddresses, string viewName, TModel model) 
@@ -46,36 +48,72 @@ public class SmtpEmailSender : IEmailSender
       Text = body
     };
 
-    var secureSocketOption = new Dictionary<int, SecureSocketOptions>
-    {
-      { 0, SecureSocketOptions.None },
-      { 1, SecureSocketOptions.Auto },
-      { 2, SecureSocketOptions.SslOnConnect },
-      { 3, SecureSocketOptions.StartTls },
-      { 4, SecureSocketOptions.StartTlsWhenAvailable }
-    };
-    try
-    {
-      await _smtpClient.ConnectAsync(_config.SmtpHost, _config.SmtpPort,
-        secureSocketOption[_config.SmtpSecureSocketEnum]);
-      await _smtpClient.AuthenticateAsync(_config.SmtpUsername, _config.SmtpPassword);
-      await _smtpClient.SendAsync(message);
-
-    }
-    catch (Exception ex)
-    {
-      throw new InvalidOperationException(ex.ToString());
-    }
-    finally
-    {
-      await _smtpClient.DisconnectAsync(true);
-      _smtpClient.Dispose();
-    }
+    var smtpOptions = IsSmtpOptionsAvailable(); // check if relevant SMTP options are available
+    if (!smtpOptions) LogError("SMTP values missing or incomplete"); // if not, log custom error message
+    
+    ConnectAndAuthenticate(); // connect and authenticate 
+    SendEmailMessage(message); // send email
   }
 
   public async Task SendEmail<TModel>(EmailAddress toAddress, string viewName, TModel model)
     where TModel : class
     => await SendEmail(new List<EmailAddress> { toAddress }, viewName, model);
 
+  private bool IsSmtpOptionsAvailable()
+  {
+    // checking if the correct numeric values (port no. and secure socket enum) are supplied
+    if (_config.SmtpPort == 0 || _config.SmtpSecureSocketEnum is > 4 or <1) return false;
+    
+    // if okay, then check string values (hostname, username & password) 
+    string[] smtpStringOptions = { _config.SmtpHost, _config.SmtpUsername, _config.SmtpPassword };
+    return !smtpStringOptions.Any(string.IsNullOrEmpty);
+  }
+
+  private void ConnectAndAuthenticate()
+  {
+    // Anything above 4 or less than 1, use 1(Auto)
+    var secureSocketKey = _config.SmtpSecureSocketEnum is > 4 or < 1 ? 1 : _config.SmtpSecureSocketEnum;
+    
+    var secureSocketOption = new Dictionary<int, SecureSocketOptions>
+    {
+      { 1, SecureSocketOptions.Auto },
+      { 2, SecureSocketOptions.SslOnConnect },
+      { 3, SecureSocketOptions.StartTls },
+      { 4, SecureSocketOptions.StartTlsWhenAvailable }
+    };
+
+    try
+    {
+      _smtpClient.Connect(_config.SmtpHost, _config.SmtpPort, secureSocketOption[secureSocketKey]); 
+      _smtpClient.Authenticate(_config.SmtpUsername, _config.SmtpPassword);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex.Message); // log exception message
+      LogError("Couldn't connect or authenticate"); // log custom error message
+    }
+    
+  }
+  private void SendEmailMessage(MimeMessage message)
+  {
+    try { _smtpClient.Send(message); }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex.Message); // log exception message
+      LogError("Couldn't send a message");// log custom error message
+    }
+    finally {
+      _smtpClient.Disconnect(true);
+      _smtpClient.Dispose();
+    }
+  }
+
+  private void LogError(string customErrorMsg)
+  {
+    _logger.LogError(customErrorMsg);
+    throw new InvalidOperationException(customErrorMsg); // then throw exception
+  }
+  
+  
 
 }

--- a/website/docs/users/getting-started/configuration/manager.md
+++ b/website/docs/users/getting-started/configuration/manager.md
@@ -26,6 +26,23 @@ OutboundEmail:
   # If Provider == "sendgrid"
   SendGridApiKey: ""
 
+  # If Provider == "smtp"
+  SmtpHost: "" # SMTP host name
+  SmtpPort:    # SMTP port
+  SmtpUsername: "" # SMTP username
+  SmtpPassword: "" # SMTP password
+  SmtpSecureSocketEnum: # for example, assign 2 to implement SslOnConnect
+  # Secure socket options
+  # 1 - Auto
+  # 2 - SslOnConnect
+  # 3 - StartTls
+  # 4 - StartTlsWhenAvailable
+
+  # More information can be found here
+  # http://www.mimekit.net/docs/html/T_MailKit_Security_SecureSocketOptions.htm
+
+  
+
 ActivitySourcePolling:
   PollingInterval: 5 # set to a negative value will disable polling altogether
 


### PR DESCRIPTION
## Overview

Add SMTP support for the Hutch using a .NET library MailKit.

- Investigate SMTP libraries for .NET 6
- SmtpEmailSender implementation
- SmtpEmailOptions class
- Register and Configure SmtpEmailSender with DI
- Update Manager Configuration documentation

## Azure Boards

- AB#83760
- AB#83758
- AB#83763
- AB#83765
- AB#83768
- AB#83769
