### PR TITLE
AB#85558: Update CheckIn endpoint to link DataSources with Agents

### DIFF
--- a/app/HutchManager/Controllers/AgentsController.cs
+++ b/app/HutchManager/Controllers/AgentsController.cs
@@ -23,7 +23,7 @@ public class AgentsController : ControllerBase
   public async Task<IActionResult> CheckIn(AgentCheckInModel payload)
   {
     foreach (var ds in payload.DataSources) 
-      await _dataSources.CreateOrUpdate(new() { Id = ds });
+      await _dataSources.CreateOrUpdate(new() { Id = ds },payload.Agents);
     return Accepted();
   }
 

--- a/app/HutchManager/Models/AgentCheckinModel.cs
+++ b/app/HutchManager/Models/AgentCheckinModel.cs
@@ -3,4 +3,6 @@ namespace HutchManager.Models;
 public class AgentCheckInModel
 {
   public List<string> DataSources { get; set; } = new();
+
+  public List<int> Agents { get; set; } = new();
 }

--- a/app/HutchManager/Services/DataSourceService.cs
+++ b/app/HutchManager/Services/DataSourceService.cs
@@ -20,18 +20,22 @@ public class DataSourceService
     return list.ConvertAll<Models.DataSource>(x => new(x));
   }
 
-  public async Task<Models.DataSource> CreateOrUpdate(Models.DataSource dataSource)
+  public async Task<Models.DataSource> CreateOrUpdate(Models.DataSource dataSource, List<int> agents)
   {
-    var entity = await _db.DataSources
+    var entity = await _db.DataSources.Include(x=>x.Agents)
       .FirstOrDefaultAsync(x => x.Id == dataSource.Id);
+    
+    //Get Agent from id
+    var agentIds = _db.Agents.Where(x => agents.Contains(x.Id)).ToList();
     
     if (entity is null)
     {
       // create new Datasource with LastCheckin set as now
-      entity = new DataSource
+      entity = new DataSource()
       {
         Id = dataSource.Id,
         LastCheckin = DateTimeOffset.UtcNow,
+        Agents = agentIds
       };
       await _db.DataSources.AddAsync(entity);
     }
@@ -39,8 +43,15 @@ public class DataSourceService
     {
       // update Datasource LastCheckin to now
       entity.LastCheckin = DateTimeOffset.UtcNow;
+      
+      // check if new agents are checking in
+      var uniqueAgents = agentIds.Except(entity.Agents).ToList();
+      if (uniqueAgents.Any())
+      {
+        // add new agents to DataSource Agents
+        entity.Agents.AddRange(uniqueAgents);
+      }
     }
-
     await _db.SaveChangesAsync();
     return new(entity);
   }


### PR DESCRIPTION
## Overview
- Modify 'api/agents/checkin' endpoint to link DataSources and Agents on check in
- Allows multiple agents to check in to multiple datasources
- If no new agents are checking in, only updates the LastCheckIn field


## Azure Boards

- AB#85561
- AB#85562
