### PR TITLE
AB#85317: Add POST method to generate user account activation link and complete account activation

### DIFF
--- a/app/HutchManager/Constants/ClientRoutes.cs
+++ b/app/HutchManager/Constants/ClientRoutes.cs
@@ -13,5 +13,5 @@ public static class ClientRoutes
 
   public const string ConfirmEmailChange = "/account/ConfirmEmailChange";
   
-  public const string ConfirmAccountActivation = "/account/activate";
+  public const string ConfirmAccountActivation = "/account/activate"; // path to account activation page
 }

--- a/app/HutchManager/Constants/ClientRoutes.cs
+++ b/app/HutchManager/Constants/ClientRoutes.cs
@@ -12,4 +12,6 @@ public static class ClientRoutes
   public const string ResendConfirm = "/account/confirm/resend";
 
   public const string ConfirmEmailChange = "/account/ConfirmEmailChange";
+  
+  public const string ConfirmAccountActivation = "/account/activate";
 }

--- a/app/HutchManager/Controllers/AccountController.cs
+++ b/app/HutchManager/Controllers/AccountController.cs
@@ -5,6 +5,7 @@ using HutchManager.Models.Account;
 using HutchManager.Models.User;
 using HutchManager.Services;
 using HutchManager.Extensions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 
@@ -247,7 +248,17 @@ public class AccountController : ControllerBase
     });
   }
   
-  [HttpPost("activate")]
+  [Authorize]
+  [HttpPost("{userIdOrEmail}/activation")] //api/account/{userIdOrEmail}/activation
+  public async Task<IActionResult> GenerateAccountActivationLink(string userIdOrEmail)
+  {
+    var user = await _users.FindByIdAsync(userIdOrEmail);
+    if (user is null) user = await _users.FindByEmailAsync(userIdOrEmail);
+    if (user is null) return NotFound();
+    return Ok(await _tokens.GenerateAccountActivationLink(user)); // return activation link
+  }
+  
+  [HttpPost("activate")] //api/account/activate
   public async Task<IActionResult> Activate (AnonymousSetPasswordModel model)
   {
     if (ModelState.IsValid)

--- a/app/HutchManager/Controllers/AccountController.cs
+++ b/app/HutchManager/Controllers/AccountController.cs
@@ -265,17 +265,20 @@ public class AccountController : ControllerBase
     {
       var user = await _users.FindByIdAsync(model.Credentials.UserId);
       if (user is null) return NotFound();
-
+      
       var isTokenValid = await _users.VerifyUserTokenAsync(user, "Default", "ActivateAccount", model.Credentials.Token); // validate token
-
+      
       if (!isTokenValid) return BadRequest();
       
+      // if token is valid, then do the following
       var hashedPassword = _users.PasswordHasher.HashPassword(user, model.Data.Password); // hash the password
-      user.AccountConfirmed = true; // update Account status
       user.PasswordHash = hashedPassword; // update password
+      user.AccountConfirmed = true; // update Account status
+      
       await _users.UpdateAsync(user); // update the user
 
       await _signIn.SignInAsync(user, false); // sign in the user
+      
       var profile = await _user.BuildProfile(user);
       // Write a basic Profile Cookie for JS
       HttpContext.Response.Cookies.Append(

--- a/app/HutchManager/Controllers/AccountController.cs
+++ b/app/HutchManager/Controllers/AccountController.cs
@@ -259,10 +259,8 @@ public class AccountController : ControllerBase
 
       if (!isTokenValid) return BadRequest();
       
-      user.EmailConfirmed = true;
+      user.AccountConfirmed = true;
       await _users.UpdateAsync(user);
-
-      if (!user.EmailConfirmed) return BadRequest();
       await _signIn.SignInAsync(user, false);
       var profile = await _user.BuildProfile(user);
       // Write a basic Profile Cookie for JS

--- a/app/HutchManager/Controllers/UserController.cs
+++ b/app/HutchManager/Controllers/UserController.cs
@@ -18,18 +18,15 @@ public class UserController : ControllerBase
   private readonly UserManager<ApplicationUser> _users;
   private readonly SignInManager<ApplicationUser> _signIn;
   private readonly UserService _user;
-  private readonly TokenIssuingService _tokens;
 
   public UserController(
     UserManager<ApplicationUser> users,
     SignInManager<ApplicationUser> signIn,
-    UserService user,
-    TokenIssuingService tokens)
+    UserService user)
   {
     _users = users;
     _signIn = signIn;
     _user = user;
-    _tokens = tokens;
   }
 
   [HttpGet("me")]
@@ -72,14 +69,4 @@ public class UserController : ControllerBase
     await _user.Create(user);
     return Ok(user);
   }
-  
-  [HttpPost("{userIdOrEmail}/activation")] //api/users/{userIdOrEmail}/activation
-  public async Task<IActionResult> GenerateAccountActivationLink(string userIdOrEmail)
-  {
-    var user = await _users.FindByIdAsync(userIdOrEmail);
-    if (user is null) user = await _users.FindByEmailAsync(userIdOrEmail);
-    if (user is null) return NotFound();
-    return Ok(await _tokens.GenerateAccountActivationLink(user));
-  }
 }
-

--- a/app/HutchManager/Controllers/UserController.cs
+++ b/app/HutchManager/Controllers/UserController.cs
@@ -72,8 +72,7 @@ public class UserController : ControllerBase
     await _user.Create(user);
     return Ok(user);
   }
-
-  [AllowAnonymous]
+  
   [HttpPost("{userIdOrEmail}/activation")] //api/users/{userIdOrEmail}/activation
   public async Task<IActionResult> GenerateAccountActivationLink(string userIdOrEmail)
   {

--- a/app/HutchManager/Controllers/UserController.cs
+++ b/app/HutchManager/Controllers/UserController.cs
@@ -70,3 +70,4 @@ public class UserController : ControllerBase
     return Ok(user);
   }
 }
+

--- a/app/HutchManager/Data/Entities/Identity/ApplicationUser.cs
+++ b/app/HutchManager/Data/Entities/Identity/ApplicationUser.cs
@@ -10,4 +10,5 @@ public class ApplicationUser : IdentityUser
   [PersonalData]
   public string UICulture { get; set; } = string.Empty;
 
+  public bool AccountConfirmed { get; set; }
 }

--- a/app/HutchManager/Data/Migrations/20221205222146_Extend_IdentityUser.Designer.cs
+++ b/app/HutchManager/Data/Migrations/20221205222146_Extend_IdentityUser.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using HutchManager.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HutchManager.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221205222146_Extend_IdentityUser")]
+    partial class Extend_IdentityUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/app/HutchManager/Data/Migrations/20221205222146_Extend_IdentityUser.cs
+++ b/app/HutchManager/Data/Migrations/20221205222146_Extend_IdentityUser.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HutchManager.Migrations
+{
+    public partial class Extend_IdentityUser : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AccountConfirmed",
+                table: "AspNetUsers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AccountConfirmed",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/app/HutchManager/Models/Account/TokenLinkModel.cs
+++ b/app/HutchManager/Models/Account/TokenLinkModel.cs
@@ -1,0 +1,7 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace HutchManager.Models.Account;
+
+public record TokenLinkModel(
+  string Link);
+

--- a/app/HutchManager/Models/Account/TokenLinkModel.cs
+++ b/app/HutchManager/Models/Account/TokenLinkModel.cs
@@ -1,7 +1,0 @@
-using System.ComponentModel.DataAnnotations;
-
-namespace HutchManager.Models.Account;
-
-public record TokenLinkModel(
-  string Link);
-

--- a/app/HutchManager/Models/Account/UserActivationTokenModel.cs
+++ b/app/HutchManager/Models/Account/UserActivationTokenModel.cs
@@ -1,0 +1,7 @@
+namespace HutchManager.Models.Account;
+
+public record UserActivationTokenModel
+{
+  public string ActivationLink { get; set; } = string.Empty;
+}
+

--- a/app/HutchManager/Services/TokenIssuingService.cs
+++ b/app/HutchManager/Services/TokenIssuingService.cs
@@ -7,6 +7,7 @@ using HutchManager.Extensions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using System.Text.Json;
 
 namespace HutchManager.Services;
 
@@ -85,6 +86,18 @@ public class TokenIssuingService
         resendLink: (ClientRoutes.ResendConfirm + // TODO
             $"?vm={new { UserId = user.Id }.ObjectToBase64UrlJson()}")
             .ToLocalUrlString(_actionContext.HttpContext.Request));
+  }
+
+  public async Task<TokenLinkModel> GenerateAccountActivationLink(ApplicationUser user)
+  {
+    var token = await _users.GenerateUserTokenAsync(user, "Default","ActivateAccount");
+    var vm = new UserTokenModel(user.Id, token);
+
+    var link = (ClientRoutes.ConfirmAccountActivation +
+                $"?vm={vm.ObjectToBase64UrlJson()}")
+      .ToLocalUrlString(_actionContext.HttpContext.Request);
+
+    return new TokenLinkModel(link);
   }
 }
 

--- a/app/HutchManager/Services/TokenIssuingService.cs
+++ b/app/HutchManager/Services/TokenIssuingService.cs
@@ -7,7 +7,6 @@ using HutchManager.Extensions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using System.Text.Json;
 
 namespace HutchManager.Services;
 
@@ -88,16 +87,19 @@ public class TokenIssuingService
             .ToLocalUrlString(_actionContext.HttpContext.Request));
   }
 
-  public async Task<TokenLinkModel> GenerateAccountActivationLink(ApplicationUser user)
+  public async Task<UserActivationTokenModel> GenerateAccountActivationLink(ApplicationUser user)
   {
     var token = await _users.GenerateUserTokenAsync(user, "Default","ActivateAccount");
     var vm = new UserTokenModel(user.Id, token);
 
-    var link = (ClientRoutes.ConfirmAccountActivation +
+    var activationLink = (ClientRoutes.ConfirmAccountActivation +
                 $"?vm={vm.ObjectToBase64UrlJson()}")
       .ToLocalUrlString(_actionContext.HttpContext.Request);
 
-    return new TokenLinkModel(link);
+    return new UserActivationTokenModel()
+    {
+      ActivationLink = activationLink
+    };
   }
 }
 


### PR DESCRIPTION
## Overview

- Add new column `AccountConfirmed` to store account activation status

- **Add `GenerateAccountActivationLink` method to `TokenIssuingService`**
  - Add attribute `Authorize' to ensure only authenticated users can action this request.
  - Generate an user activation link that can be passed to the user. 
  - The link takes user to `account/activate` page where user can set password and activate their account.
  
- **Activate Account backend POST route in `AccountController`**
  - Validate token when it receives a request to activate user account with a payload (includes `Token`, `Password` and `Userid`)
  - Then, hash the password and update user `PasswordHash` and `AccountConfirmed` status to mark account as active

## Azure Boards

- AB#85317
- AB#85320
- AB#87488

