### PR TITLE
AB#85294: Admin Password Reset link (re)generation

### DIFF
--- a/app/HutchManager/Controllers/AccountController.cs
+++ b/app/HutchManager/Controllers/AccountController.cs
@@ -289,4 +289,14 @@ public class AccountController : ControllerBase
     }
     return BadRequest();
   }
+  
+  [Authorize]
+  [HttpPost("{userIdOrEmail}/password/reset")] //api/account/{userIdOrEmail}/password/reset
+  public async Task<IActionResult> GeneratePasswordResetLink(string userIdOrEmail)
+  {
+    var user = await _users.FindByIdAsync(userIdOrEmail);
+    if (user is null) user = await _users.FindByEmailAsync(userIdOrEmail);
+    if (user is null) return NotFound();
+    return Ok(await _tokens.GeneratePasswordResetLink(user)); // return password reset link
+  }
 }

--- a/app/HutchManager/Controllers/AccountController.cs
+++ b/app/HutchManager/Controllers/AccountController.cs
@@ -289,11 +289,7 @@ public class AccountController : ControllerBase
         AuthConfiguration.ProfileCookieName,
         JsonSerializer.Serialize((BaseUserProfileModel)profile),
         AuthConfiguration.ProfileCookieOptions);
-      return Ok(new SetPasswordResult
-      {
-        User = profile,
-        IsUnconfirmedAccount = !user.AccountConfirmed // Is account not confirmed? 'FALSE' if account confirmed, else 'TRUE'
-      });
+      return Ok(new SetPasswordResult { User = profile});
     }
     return BadRequest(new SetPasswordResult
     {

--- a/app/HutchManager/Controllers/AccountController.cs
+++ b/app/HutchManager/Controllers/AccountController.cs
@@ -261,44 +261,44 @@ public class AccountController : ControllerBase
   [HttpPost("activate")] //api/account/activate
   public async Task<IActionResult> Activate (AnonymousSetAccountActivateModel model)
   {
-      if (ModelState.IsValid)
-      {
-        var user = await _users.FindByIdAsync(model.Credentials.UserId);
-        if (user is null) return NotFound();
+    if (ModelState.IsValid)
+    { 
+      var user = await _users.FindByIdAsync(model.Credentials.UserId);
+      if (user is null) return NotFound();
       
-        var isTokenValid = await _users.VerifyUserTokenAsync(user, "Default", "ActivateAccount", model.Credentials.Token); // validate token
+      var isTokenValid = await _users.VerifyUserTokenAsync(user, "Default", "ActivateAccount", model.Credentials.Token); // validate token
       
-        if (!isTokenValid) return BadRequest(new SetPasswordResult
-        {
-          Errors = ModelState.CollapseErrors()
-        });
-      
-        // if token is valid, then do the following
-        var hashedPassword = _users.PasswordHasher.HashPassword(user, model.Data.Password); // hash the password
-        user.PasswordHash = hashedPassword; // update password
-        user.AccountConfirmed = true; // update Account status
-        user.FullName = model.Data.FullName; // update user full name
-      
-        await _users.UpdateAsync(user); // update the user
-
-        await _signIn.SignInAsync(user, false); // sign in the user
-      
-        var profile = await _user.BuildProfile(user);
-        // Write a basic Profile Cookie for JS
-        HttpContext.Response.Cookies.Append(
-          AuthConfiguration.ProfileCookieName,
-          JsonSerializer.Serialize((BaseUserProfileModel)profile),
-          AuthConfiguration.ProfileCookieOptions);
-        return Ok(new SetPasswordResult
-        {
-          User = profile,
-          IsUnconfirmedAccount = !user.AccountConfirmed // Is account not confirmed? 'FALSE' if account confirmed, else 'TRUE'
-        });
-      }
-      return BadRequest(new SetPasswordResult
+      if (!isTokenValid) return BadRequest(new SetPasswordResult
       {
         Errors = ModelState.CollapseErrors()
       });
+      
+      // if token is valid, then do the following
+      var hashedPassword = _users.PasswordHasher.HashPassword(user, model.Data.Password); // hash the password
+      user.PasswordHash = hashedPassword; // update password
+      user.AccountConfirmed = true; // update Account status
+      user.FullName = model.Data.FullName; // update user full name
+      
+      await _users.UpdateAsync(user); // update the user
+
+      await _signIn.SignInAsync(user, false); // sign in the user
+      
+      var profile = await _user.BuildProfile(user);
+      // Write a basic Profile Cookie for JS
+      HttpContext.Response.Cookies.Append(
+        AuthConfiguration.ProfileCookieName,
+        JsonSerializer.Serialize((BaseUserProfileModel)profile),
+        AuthConfiguration.ProfileCookieOptions);
+      return Ok(new SetPasswordResult
+      {
+        User = profile,
+        IsUnconfirmedAccount = !user.AccountConfirmed // Is account not confirmed? 'FALSE' if account confirmed, else 'TRUE'
+      });
+    }
+    return BadRequest(new SetPasswordResult
+    {
+      Errors = ModelState.CollapseErrors()
+    });
   }
   
   [Authorize]

--- a/app/HutchManager/Controllers/AccountController.cs
+++ b/app/HutchManager/Controllers/AccountController.cs
@@ -215,9 +215,9 @@ public class AccountController : ControllerBase
 
       if (!result.Errors.Any())
       {
-        if (user.EmailConfirmed)
+        if (user.AccountConfirmed) // check if AccountConfirmed
         {
-          await _signIn.SignInAsync(user, false);
+          await _signIn.SignInAsync(user, false); 
 
           var profile = await _user.BuildProfile(user);
 
@@ -234,7 +234,7 @@ public class AccountController : ControllerBase
         }
         else
         {
-          return Ok(new SetPasswordResult
+          return Ok(new SetPasswordResult 
           {
             IsUnconfirmedAccount = true
           });

--- a/app/HutchManager/Controllers/AccountController.cs
+++ b/app/HutchManager/Controllers/AccountController.cs
@@ -261,34 +261,44 @@ public class AccountController : ControllerBase
   [HttpPost("activate")] //api/account/activate
   public async Task<IActionResult> Activate (AnonymousSetAccountActivateModel model)
   {
-    if (ModelState.IsValid)
-    {
-      var user = await _users.FindByIdAsync(model.Credentials.UserId);
-      if (user is null) return NotFound();
+      if (ModelState.IsValid)
+      {
+        var user = await _users.FindByIdAsync(model.Credentials.UserId);
+        if (user is null) return NotFound();
       
-      var isTokenValid = await _users.VerifyUserTokenAsync(user, "Default", "ActivateAccount", model.Credentials.Token); // validate token
+        var isTokenValid = await _users.VerifyUserTokenAsync(user, "Default", "ActivateAccount", model.Credentials.Token); // validate token
       
-      if (!isTokenValid) return BadRequest();
+        if (!isTokenValid) return BadRequest(new SetPasswordResult
+        {
+          Errors = ModelState.CollapseErrors()
+        });
       
-      // if token is valid, then do the following
-      var hashedPassword = _users.PasswordHasher.HashPassword(user, model.Data.Password); // hash the password
-      user.PasswordHash = hashedPassword; // update password
-      user.AccountConfirmed = true; // update Account status
-      user.FullName = model.Data.FullName; // update user full name
+        // if token is valid, then do the following
+        var hashedPassword = _users.PasswordHasher.HashPassword(user, model.Data.Password); // hash the password
+        user.PasswordHash = hashedPassword; // update password
+        user.AccountConfirmed = true; // update Account status
+        user.FullName = model.Data.FullName; // update user full name
       
-      await _users.UpdateAsync(user); // update the user
+        await _users.UpdateAsync(user); // update the user
 
-      await _signIn.SignInAsync(user, false); // sign in the user
+        await _signIn.SignInAsync(user, false); // sign in the user
       
-      var profile = await _user.BuildProfile(user);
-      // Write a basic Profile Cookie for JS
-      HttpContext.Response.Cookies.Append(
-        AuthConfiguration.ProfileCookieName,
-        JsonSerializer.Serialize((BaseUserProfileModel)profile),
-        AuthConfiguration.ProfileCookieOptions);
-      return Ok(profile);
-    }
-    return BadRequest();
+        var profile = await _user.BuildProfile(user);
+        // Write a basic Profile Cookie for JS
+        HttpContext.Response.Cookies.Append(
+          AuthConfiguration.ProfileCookieName,
+          JsonSerializer.Serialize((BaseUserProfileModel)profile),
+          AuthConfiguration.ProfileCookieOptions);
+        return Ok(new SetPasswordResult
+        {
+          User = profile,
+          IsUnconfirmedAccount = !user.AccountConfirmed // Is account not confirmed? 'FALSE' if account confirmed, else 'TRUE'
+        });
+      }
+      return BadRequest(new SetPasswordResult
+      {
+        Errors = ModelState.CollapseErrors()
+      });
   }
   
   [Authorize]

--- a/app/HutchManager/Models/Account/UserPasswordResetTokenModel.cs
+++ b/app/HutchManager/Models/Account/UserPasswordResetTokenModel.cs
@@ -1,0 +1,7 @@
+namespace HutchManager.Models.Account;
+
+public record UserPasswordResetTokenModel
+{
+  public string PasswordResetLink { get; set; } = string.Empty;
+}
+

--- a/app/HutchManager/Services/TokenIssuingService.cs
+++ b/app/HutchManager/Services/TokenIssuingService.cs
@@ -104,17 +104,11 @@ public class TokenIssuingService
   
   public async Task<UserPasswordResetTokenModel> GeneratePasswordResetLink(ApplicationUser user)
   {
-    var token = await _users.GeneratePasswordResetTokenAsync(user);
-    var vm = new UserTokenModel(user.Id, token);
-
-    var pwdResetLink = (ClientRoutes.ResetPassword +
-                          $"?vm={vm.ObjectToBase64UrlJson()}")
-      .ToLocalUrlString(_actionContext.HttpContext.Request);
-
-    return new UserPasswordResetTokenModel()
-    {
-      PasswordResetLink = pwdResetLink
-    };
+    var token = await _users.GeneratePasswordResetTokenAsync(user); // Generate password reset token
+    var vm = new UserTokenModel(user.Id, token); // create an object with userId and pwd reset token
+    var pwdResetLink = (ClientRoutes.ResetPassword + $"?vm={vm.ObjectToBase64UrlJson()}")
+      .ToLocalUrlString(_actionContext.HttpContext.Request); // create a link
+    return new UserPasswordResetTokenModel() { PasswordResetLink = pwdResetLink }; // return password reset link
   }
 }
 

--- a/app/HutchManager/Services/TokenIssuingService.cs
+++ b/app/HutchManager/Services/TokenIssuingService.cs
@@ -101,5 +101,20 @@ public class TokenIssuingService
       ActivationLink = activationLink
     };
   }
+  
+  public async Task<UserPasswordResetTokenModel> GeneratePasswordResetLink(ApplicationUser user)
+  {
+    var token = await _users.GeneratePasswordResetTokenAsync(user);
+    var vm = new UserTokenModel(user.Id, token);
+
+    var pwdResetLink = (ClientRoutes.ResetPassword +
+                          $"?vm={vm.ObjectToBase64UrlJson()}")
+      .ToLocalUrlString(_actionContext.HttpContext.Request);
+
+    return new UserPasswordResetTokenModel()
+    {
+      PasswordResetLink = pwdResetLink
+    };
+  }
 }
 

--- a/app/manager-frontend/public/locales/dev/core.json
+++ b/app/manager-frontend/public/locales/dev/core.json
@@ -13,7 +13,8 @@
       "resendConfirm_title": "Request a new confirmation link",
       "resendConfirm_link": "Send me a new confirmation link via email",
       "invalidResendLink": "Your resend link is invalid. Please try to get a new one, or contact support.",
-      "unconfirmed": "Your account email address has not been confirmed."
+      "unconfirmedEmail": "Your account email address has not been confirmed.",
+      "unconfirmedAccount": "Your account has not been activated."
     }
   },
   "fields": {

--- a/app/manager-frontend/src/api/user.js
+++ b/app/manager-frontend/src/api/user.js
@@ -45,6 +45,10 @@ export const getUserApi = ({ api }) => ({
     api.delete(`users/${id}`, {
       json: values,
     }),
+  generatePasswordResetLink: ({ values, id }) =>
+    api.post(`account/${id}/password/reset`, {
+      json: values,
+    }),
 });
 
 export const useUserList = () => {

--- a/app/manager-frontend/src/components/users/UserSummary.jsx
+++ b/app/manager-frontend/src/components/users/UserSummary.jsx
@@ -85,7 +85,8 @@ export const UserSummary = ({
       // applicable for handling password reset link
       name: "passwordResetLink",
       title: "Password reset",
-      apiAction: async () => {}, // TODO use for making api call to generate password reset link
+      apiAction: async () =>
+        users.generatePasswordResetLink({ id: userId }).json(),
     },
   };
 
@@ -94,6 +95,7 @@ export const UserSummary = ({
       try {
         setIsLoading(true);
         const actionResponse = await selectedAction.apiAction(); // get requested link
+        console.log(actionResponse);
         setActivationOrPwdResetLink(actionResponse[selectedAction.name]); // update the state with the link received
         displayToast({
           title: `New ${selectedAction.title} link generated`,
@@ -234,6 +236,18 @@ export const UserSummary = ({
                   onClick={() => setSelectedAction(actionMenu.accountActivate)}
                 >
                   Generate {actionMenu.accountActivate.title}
+                </Button>
+              </HStack>
+            )}
+            {isUserActive && (
+              <HStack pt="10px" justifyContent="end">
+                <Button
+                  size="sm"
+                  colorScheme="blue"
+                  leftIcon={<FaLink />}
+                  onClick={() => setSelectedAction(actionMenu.passwordReset)}
+                >
+                  Generate {actionMenu.passwordReset.title}
                 </Button>
               </HStack>
             )}

--- a/app/manager-frontend/src/components/users/UserSummary.jsx
+++ b/app/manager-frontend/src/components/users/UserSummary.jsx
@@ -95,7 +95,6 @@ export const UserSummary = ({
       try {
         setIsLoading(true);
         const actionResponse = await selectedAction.apiAction(); // get requested link
-        console.log(actionResponse);
         setActivationOrPwdResetLink(actionResponse[selectedAction.name]); // update the state with the link received
         displayToast({
           title: `New ${selectedAction.title} link generated`,

--- a/app/manager-frontend/src/pages/account/ResetPassword.jsx
+++ b/app/manager-frontend/src/pages/account/ResetPassword.jsx
@@ -100,7 +100,7 @@ export const ResetPassword = () => {
             },
             {
               status: "warning",
-              message: t("feedback.account.unconfirmed"),
+              message: t("feedback.account.unconfirmedAccount"),
             },
           ],
 


### PR DESCRIPTION
## Overview

- Add `GeneratePasswordResetLink` to `TokenIssuingService`
- Add `Reset Password` Action to the Actions button menu
- Reset Password action displays modal containing the new link (and a copy button)

_Display generate password reset button only if the user is active_
![image](https://user-images.githubusercontent.com/25617324/206477450-90df3257-503d-499e-b989-898ff85127f6.png)

_Password Reset modal_
![image](https://user-images.githubusercontent.com/25617324/206477754-28e36c84-d5c6-4776-bdca-2d3710b9da7e.png)

- Update `AccountController` Activate POST method 

## Azure Boards

- AB#85330
- AB#85331
- AB#85332
- AB#85333