### PR TITLE
AB#89730: Migrations can't be generated due to no default queue config

### DIFF
--- a/app/HutchManager/Extensions/ServiceCollectionExtensions.cs
+++ b/app/HutchManager/Extensions/ServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace HutchManager.Extensions
 
     public static IServiceCollection AddJobQueue(this IServiceCollection s, IConfiguration c)
     {
-      var queueType = c["QueueType"] ?? throw new Exception("Please provide a queue type");
+      var queueType = c["JobQueue:Provider"] ?? throw new Exception("Please provide a queue type");
 
       switch (queueType)
       {

--- a/website/docs/users/getting-started/configuration/manager.md
+++ b/website/docs/users/getting-started/configuration/manager.md
@@ -68,16 +68,16 @@ RquestTaskApi:
   Password: ""
 
 # Set-up if using RabbitMQ
-QueueType: "RabbitMQ"
 JobQueue:
+  Provider: "RabbitMQ"
   HostName: ""
   Port: 5672
   UserName: "guest"
   Password: "guest"
 
 # Set-up if using Azure Queue Storage
-QueueType: "AzureQueueStorage"
 JobQueue:
+  Provider: "AzureQueueStorage"
   ConnectionString: "<your connection string>"
 
 # Opt in feature flags


### PR DESCRIPTION
## Overview

- Fix bug in manager build where a default job queue is required in the configuration. Defaults to "RabbitMQ"

## Azure Boards

- AB#89732
- AB#89736
- AB#89737
- AB#89733
- AB#89738
- AB#89739
