### PR TITLE
AB#93964: Detach One shot Agent from Manager - query results

### DIFF
--- a/app/rquest-omop-agent/pyproject.toml
+++ b/app/rquest-omop-agent/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "rquest-omop-agent"
 description = ''
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.11"
 license = "MIT"
 keywords = []
 authors = [
@@ -52,3 +52,15 @@ include = [
 "../../lib/hutch_utils" = "hutch_utils"
 "../../lib/rquest_dto" = "rquest_dto"
 "../../lib/omop_entities" = "omop_entities"
+
+[tool.hatch.envs.mysql]
+skip-install = true
+extra-dependencies = [
+  "mysqlclient~=2.1.1",
+]
+
+[tool.hatch.envs.sqlserver]
+skip-install = true
+extra-dependencies = [
+  "pyodbc~=4.0.35",
+]

--- a/app/rquest-omop-agent/rquest_omop_agent/query_solvers.py
+++ b/app/rquest-omop-agent/rquest_omop_agent/query_solvers.py
@@ -300,6 +300,8 @@ def solve_availability(
     Args:
         db_manager (SyncDBManager): The database manager
         query (AvailabilityQuery): The availability query object
+        activity_source_id (int): The ID of the activity source
+        for fetching results modifiers
 
     Returns:
         RquestResult: Result object for the query
@@ -362,16 +364,17 @@ def solve_distribution(db_manager: SyncDBManager, query: DistributionQuery) -> R
             count=count,
             datasets_count=1,
             files=[result_file],
+            collection_id=query.collection
         )
     except Exception as e:
         logger.error(str(e))
         result = RquestResult(
-            activity_source_id=query.activity_source_id,
             uuid=query.uuid,
             status="error",
             count=0,
             datasets_count=0,
             files=[],
+            collection_id=query.collection
         )
 
     return result

--- a/app/rquest-omop-agent/rquest_omop_agent/query_solvers.py
+++ b/app/rquest-omop-agent/rquest_omop_agent/query_solvers.py
@@ -290,18 +290,12 @@ class CodeDistributionQuerySolver:
         return os.linesep.join(results), len(df)
 
 
-def solve_availability(
-    db_manager: SyncDBManager,
-    query: AvailabilityQuery,
-    activity_source_id: int,
-) -> RquestResult:
+def solve_availability(db_manager: SyncDBManager, query: AvailabilityQuery) -> RquestResult:
     """Solve RQuest availability queries.
 
     Args:
         db_manager (SyncDBManager): The database manager
         query (AvailabilityQuery): The availability query object
-        activity_source_id (int): The ID of the activity source
-        for fetching results modifiers
 
     Returns:
         RquestResult: Result object for the query
@@ -309,9 +303,7 @@ def solve_availability(
     logger = logging.getLogger(config.LOGGER_NAME)
     solver = AvailibilityQuerySolver(db_manager, query)
     try:
-        res = solver.solve_query()
-        result_modifiers = get_results_modifiers(activity_source_id)
-        count_ = apply_filters(res, result_modifiers)
+        count_ = solver.solve_query()
         result = RquestResult(
             status="ok",
             count=count_,

--- a/app/rquest-omop-agent/scripts/agent.py
+++ b/app/rquest-omop-agent/scripts/agent.py
@@ -7,6 +7,7 @@ import hutch_utils.config as config
 from rquest_omop_agent import query_solvers
 from rquest_dto.query import AvailabilityQuery, DistributionQuery
 from rquest_dto.result import RquestResult
+from hutch_utils.obfuscation import get_results_modifiers_from_str, apply_filters_v2
 from rquest_omop_agent.db_manager import SyncDBManager
 
 parser = argparse.ArgumentParser(
@@ -114,9 +115,11 @@ def main() -> None:
 
     logger.info("Processing query...")
     query_dict = json.loads(args.body)
+    result_modifers = get_results_modifiers_from_str(args.results_modifiers)
     if args.is_availability:
         query = AvailabilityQuery.from_dict(query_dict)
         result = query_solvers.solve_availability(db_manager=db_manager, query=query)
+        result.count = apply_filters_v2(result.count, result_modifers)
         try:
             save_to_output(result, args.output)
             logger.info(f"Saved results to {args.output}")

--- a/app/rquest-omop-agent/scripts/agent.py
+++ b/app/rquest-omop-agent/scripts/agent.py
@@ -42,10 +42,16 @@ parser.add_argument(
     default="output.json",
     help="The path to the output file"
 )
+parser.add_argument(
+    "-m",
+    "--modifiers",
+    dest="results_modifiers",
+    required=False,
+    help="The results modifiers",
+    nargs="*",
+)
 
-def save_to_output(
-    result: RquestResult, destination: str
-) -> None:
+def save_to_output(result: RquestResult, destination: str) -> None:
     """Save the result to a JSON file.
 
     Args:

--- a/app/rquest-omop-agent/scripts/agent.py
+++ b/app/rquest-omop-agent/scripts/agent.py
@@ -9,7 +9,7 @@ import hutch_utils.config as config
 from hutch_utils.checkin import check_in
 from rquest_omop_agent import query_solvers
 from rquest_dto.query import AvailabilityQuery, DistributionQuery
-from rquest_dto.result import AvailabilityResult, RquestResult
+from rquest_dto.result import RquestResult
 from rquest_omop_agent.db_manager import SyncDBManager
 
 parser = argparse.ArgumentParser(
@@ -38,13 +38,12 @@ parser.add_argument(
 )
 
 def send_to_manager(
-    result: Union[AvailabilityResult, RquestResult], endpoint: str
+    result: RquestResult, endpoint: str
 ) -> None:
     """Send a result RO-Crate to the manager.
 
     Args:
-        result (Union[AvailabilityResult, DistributionResult]): 
-            The RO-Crate object containing the result of a query.
+        result (RquestResult): The object containing the result of a query.
         endpoint (str): The endpoint at the manager to send the result.
     """
     logger = logging.getLogger(config.LOGGER_NAME)

--- a/app/rquest-omop-agent/scripts/agent.py
+++ b/app/rquest-omop-agent/scripts/agent.py
@@ -114,7 +114,7 @@ def main() -> None:
             save_to_output(result, args.output)
             logger.info(f"Saved results to {args.output}")
         except ValueError as e:
-            logger.critical(str(e), exc_info=True)
+            logger.error(str(e), exc_info=True)
     else:
         query = DistributionQuery.from_dict(query_dict)
         result = query_solvers.solve_distribution(db_manager=db_manager, query=query)
@@ -122,4 +122,4 @@ def main() -> None:
             save_to_output(result, args.output)
             logger.info(f"Saved results to {args.output}")
         except ValueError as e:
-            logger.critical(str(e), exc_info=True)
+            logger.error(str(e), exc_info=True)

--- a/app/rquest-omop-agent/scripts/agent.py
+++ b/app/rquest-omop-agent/scripts/agent.py
@@ -36,6 +36,14 @@ parser.add_argument(
     action="store_true",
     help="The query is a distribution query"
 )
+parser.add_argument(
+    "-o",
+    "--output",
+    dest="output",
+    required=False,
+    default="output.json",
+    help="The path to the output file"
+)
 
 def send_to_manager(
     result: RquestResult, endpoint: str

--- a/app/rquest-omop-agent/scripts/agent.py
+++ b/app/rquest-omop-agent/scripts/agent.py
@@ -47,8 +47,9 @@ parser.add_argument(
     "--modifiers",
     dest="results_modifiers",
     required=False,
+    type=str,
+    default="[]",  # when parsed will produce an empty list
     help="The results modifiers",
-    nargs="*",
 )
 
 def save_to_output(result: RquestResult, destination: str) -> None:

--- a/lib/hutch_utils/obfuscation.py
+++ b/lib/hutch_utils/obfuscation.py
@@ -1,6 +1,7 @@
+import json
 import os
 import requests
-from typing import Union
+from typing import Union, List
 
 
 def get_results_modifiers(activity_source_id: int) -> list:
@@ -22,6 +23,27 @@ def get_results_modifiers(activity_source_id: int) -> list:
     res.raise_for_status()
     modifiers = res.json()
     return modifiers
+
+
+def get_results_modifiers_from_str(params: str) -> list:
+    """Deserialise a JSON list containing results modifiers
+
+    Args:
+        params (str):
+        The JSON string containing list of parameter objects for results modifiers
+
+    Raises:
+        ValueError: The parsed string does not produce a list
+
+    Returns:
+        list: The list of parameter dicts of results modifiers
+    """
+    params = json.loads(params)
+    if type(params) is not list:
+        raise ValueError(
+            f"{get_results_modifiers_from_str.__name__} requires a JSON list"
+        )
+    return params
 
 
 def low_number_suppression(

--- a/lib/hutch_utils/obfuscation.py
+++ b/lib/hutch_utils/obfuscation.py
@@ -1,7 +1,7 @@
 import json
 import os
 import requests
-from typing import Union, List
+from typing import Union
 
 
 def get_results_modifiers(activity_source_id: int) -> list:
@@ -102,6 +102,26 @@ def apply_filters(value: Union[int, float], filters: list) -> Union[int, float]:
     for f in filters:
         if action := actions.get(f["type"]["id"]):
             result = action(result, **f["parameters"])
+            if result == 0:
+                break  # don't apply any more filters
+    return result
+
+
+def apply_filters_v2(value: Union[int, float], filters: list) -> Union[int, float]:
+    """Iterate over a list of filters and apply them to the supplied value.
+
+    Args:
+        value (Union[int, float]): The value to be filtered.
+        filters (list): The filters applied to the value.
+
+    Returns:
+        Union[int, float]: The filtered value.
+    """
+    actions = {"Low Number Suppression": low_number_suppression, "Rounding": rounding}
+    result = value
+    for f in filters:
+        if action := actions.get(f.pop("id", None)):
+            result = action(result, **f)
             if result == 0:
                 break  # don't apply any more filters
     return result


### PR DESCRIPTION
## Overview

- One shot app is independent of the Manager.
- The app takes the body of a query and optionally some results modifiers, both in JSON format, and solves the query.
- The output is saved to disk. The user may optionally give a path to save the file to.

## Azure Boards

- AB#93965
- AB#93966
- AB#93967
- AB#93968
- AB#94032
- AB#93969

## Notes
- new usage help message:
```shell
usage: rquest-omop-agent [-h] --body BODY [-a] [-d] [-o OUTPUT] [-m RESULTS_MODIFIERS]

This program takes a JSON string containing an RQuest query and solves it.

options:
  -h, --help            show this help message and exit
  --body BODY           The JSON string containing the query
  -a, --availability    The query is a availability query
  -d, --distribution    The query is a distribution query
  -o OUTPUT, --output OUTPUT
                        The path to the output file
  -m RESULTS_MODIFIERS, --modifiers RESULTS_MODIFIERS
                        The results modifiers
```

- Format of the results modifiers:
```jsonc
[
  {
    "id": "Low Number Suppression:",
    "threshold": 1000
  },
  {
    "id": "Rounding",
    "nearest": 100
  },
  ...

]
