### PR TITLE
AB#89065: Disallow admin account deletion

### DIFF
--- a/app/HutchManager/Models/User/UserModel.cs
+++ b/app/HutchManager/Models/User/UserModel.cs
@@ -17,6 +17,8 @@ public class UserModel
 
   public string Id { get; set; } = string.Empty;
   
+  public bool IsProtected { get; set; }
+  
   public UserModel(ApplicationUser entity)
     {
       Username = entity.UserName;

--- a/app/HutchManager/Services/UserService.cs
+++ b/app/HutchManager/Services/UserService.cs
@@ -136,7 +136,18 @@ public class UserService
     var list = await _db.Users
       .AsNoTracking()
       .ToListAsync();
-    return list.ConvertAll<UserModel>(x => new(x));
+    var userList=list.ConvertAll<UserModel>(x => new(x));
+    try
+    {
+      userList.Find(e => e.Username == "@admin")!.IsProtected = true;
+
+    }
+    catch
+    {
+      throw new KeyNotFoundException();
+    }
+
+    return userList;
   }
   
   /// <summary>

--- a/app/manager-frontend/src/pages/User/list.jsx
+++ b/app/manager-frontend/src/pages/User/list.jsx
@@ -86,8 +86,9 @@ export const UsersList = () => {
               username={item.username}
               isUserActive={item.accountConfirmed}
               onDelete={
-                // Prevent user from deleting itself
-                // exclude delete action from the summary card for the logged in user
+                // Prevent user from deleting itself & superadmin
+                // exclude delete action from the summary card for the logged in user & admin
+                !item.isProtected &&
                 item.fullName !== user.fullName &&
                 item.email !== user.email &&
                 (() => onClickDelete(item))


### PR DESCRIPTION
## Overview

- Add isProtected flag to UserModel,
- Set it to true for admin account in List action
- Check isProtected flag in the frontend and disable delete button if true

## Azure Boards

- AB#89067
- AB#89068
- AB#89066
- AB#89069
