### PR TITLE
AB#94466: rquest-omop-agent docker image github workflows

### DIFF
--- a/.github/workflows/publish.rquest-omop-agent.yml
+++ b/.github/workflows/publish.rquest-omop-agent.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Build and push Docker images
         uses: docker/build-push-action@v3.1.1
         with:
-          push: true
+          # make push true before true before closing PR
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          file: app/rquest-omop-agent/Dockerfile

--- a/.github/workflows/publish.rquest-omop-agent.yml
+++ b/.github/workflows/publish.rquest-omop-agent.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [main]
   # This is for testing, remove before closing PR.
-  pull_rquest:
+  pull_request:
     types: 
       - open
     paths:

--- a/.github/workflows/publish.rquest-omop-agent.yml
+++ b/.github/workflows/publish.rquest-omop-agent.yml
@@ -8,13 +8,7 @@ on:
         required: true
         default: release
   push:
-    branches: [main, one-shot-publish-workflow]
-  # This is for testing, remove before closing PR.
-  pull_request:
-    types: 
-      - open
-    paths:
-      - '.github/workflows/*.yml'
+    branches: [main]
   
 
 jobs:
@@ -38,8 +32,6 @@ jobs:
       APP_NAME: rquest-omop-agent
       NEXT_TAG: next
       TS_TAG: ${{ needs.generate-timestamp.outputs.timestamp }}
-      # Remove before closing PR
-      TEST_TAG: test
       REGISTRY: ghcr.io
     needs: generate-timestamp
     steps:
@@ -57,17 +49,14 @@ jobs:
         uses: docker/metadata-action@v4.0.1
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.APP_NAME }}
-          # Remove TEST_tag before closing PR
           tags: |
             ${{ env.TS_TAG }}
             ${{ env.NEXT_TAG }}
-            ${{ env.TEST_TAG }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v3.1.1
         with:
-          # make push true before true before closing PR
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: app/rquest-omop-agent/Dockerfile

--- a/.github/workflows/publish.rquest-omop-agent.yml
+++ b/.github/workflows/publish.rquest-omop-agent.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: release
   push:
-    branches: [main]
+    branches: [main, one-shot-publish-workflow]
   # This is for testing, remove before closing PR.
   pull_request:
     types: 

--- a/.github/workflows/publish.rquest-omop-agent.yml
+++ b/.github/workflows/publish.rquest-omop-agent.yml
@@ -9,6 +9,13 @@ on:
         default: release
   push:
     branches: [main]
+  # This is for testing, remove before closing PR.
+  pull_rquest:
+    types: 
+      - open
+    paths:
+      - '.github/workflows/*.yml'
+  
 
 jobs:
   generate-timestamp:
@@ -22,53 +29,17 @@ jobs:
       with:
         format: "YYYYMMDDHHmmss"
 
-  publish-agent-wheel:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    env:
-      PYTHON_VERSION: "3.9"
-      POETRY_VERSION: "1.1.14"
-      WORKDIR: "./app/HutchAgent"
-      RELEASE_NAME: agent-${{ needs.generate-timestamp.outputs.timestamp }}
-    needs: generate-timestamp
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-      - name: Install agent deps
-        working-directory: ${{ env.WORKDIR }}
-        run: poetry install --no-dev
-      - name: Build dist
-        working-directory: ${{ env.WORKDIR }}
-        run: poetry build
-      - name: GH Release
-        uses: softprops/action-gh-release@v0.1.14
-        with:
-          prerelease: true
-          files: |
-            ${{ env.WORKDIR }}/dist/*
-          name: ${{ env.RELEASE_NAME }}
-          tag_name: ${{ env.RELEASE_NAME }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          generate_release_notes: true
-
   publish-agent-docker:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     env:
-      APP_NAME: agent
-      WORKDIR: ./app/HutchAgent
+      APP_NAME: rquest-omop-agent
       NEXT_TAG: next
       TS_TAG: ${{ needs.generate-timestamp.outputs.timestamp }}
+      # Remove before closing PR
+      TEST_TAG: test
       REGISTRY: ghcr.io
     needs: generate-timestamp
     steps:
@@ -86,9 +57,11 @@ jobs:
         uses: docker/metadata-action@v4.0.1
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.APP_NAME }}
+          # Remove TEST_tag before closing PR
           tags: |
             ${{ env.TS_TAG }}
             ${{ env.NEXT_TAG }}
+            ${{ env.TEST_TAG }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v3.1.1
@@ -96,4 +69,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          context: ${{ env.WORKDIR }}

--- a/.github/workflows/publish.rquest-omop-agent.yml
+++ b/.github/workflows/publish.rquest-omop-agent.yml
@@ -1,0 +1,99 @@
+name: Publish Rquest OMOP Agent
+
+on:
+  workflow_dispatch: # manual trigger
+    inputs:
+      buildConfig:
+        description: Build Configuration
+        required: true
+        default: release
+  push:
+    branches: [main]
+
+jobs:
+  generate-timestamp:
+    runs-on: ubuntu-latest
+    outputs:
+      timestamp: ${{ steps.makestamp.outputs.time }}
+    steps:
+    - name: Make Timestamp
+      id: makestamp
+      uses: nanzm/get-time-action@v1.1
+      with:
+        format: "YYYYMMDDHHmmss"
+
+  publish-agent-wheel:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: "3.9"
+      POETRY_VERSION: "1.1.14"
+      WORKDIR: "./app/HutchAgent"
+      RELEASE_NAME: agent-${{ needs.generate-timestamp.outputs.timestamp }}
+    needs: generate-timestamp
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+      - name: Install agent deps
+        working-directory: ${{ env.WORKDIR }}
+        run: poetry install --no-dev
+      - name: Build dist
+        working-directory: ${{ env.WORKDIR }}
+        run: poetry build
+      - name: GH Release
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          prerelease: true
+          files: |
+            ${{ env.WORKDIR }}/dist/*
+          name: ${{ env.RELEASE_NAME }}
+          tag_name: ${{ env.RELEASE_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true
+
+  publish-agent-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      APP_NAME: agent
+      WORKDIR: ./app/HutchAgent
+      NEXT_TAG: next
+      TS_TAG: ${{ needs.generate-timestamp.outputs.timestamp }}
+      REGISTRY: ghcr.io
+    needs: generate-timestamp
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Docker Login
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.APP_NAME }}
+          tags: |
+            ${{ env.TS_TAG }}
+            ${{ env.NEXT_TAG }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3.1.1
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          context: ${{ env.WORKDIR }}

--- a/.github/workflows/release.rquest-omop-agent.yml
+++ b/.github/workflows/release.rquest-omop-agent.yml
@@ -1,0 +1,67 @@
+name: Release Rquest OMOP Agent (stable)
+
+on:
+  workflow_dispatch: # manual trigger
+    inputs:
+      version_tag:
+        description: Version tag
+        required: true
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  get-version:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/agent-')
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION_TAG: ${{ steps.get-tag-auto.outputs.VERSION_TAG || steps.get-tag-manual.outputs.VERSION_TAG}}
+    steps:
+      - name: Get Version Tag
+        id: get-tag-auto
+        if: ${{ inputs.version_tag }} == ''
+        run: |
+          echo ::set-output name=VERSION_TAG::$(echo ${GITHUB_REF_NAME#release/rquest-omop-agent-})
+      - name: Get Version Tag (manual)
+        id: get-tag-manual
+        if: ${{ inputs.version_tag }} != ''
+        run: |
+          echo ::set-output name=VERSION_TAG::${{ inputs.version_tag }}
+
+  publish-agent-docker:
+    needs: get-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      APP_NAME: rquest-omop-agent
+      REGISTRY: ghcr.io
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Docker Login
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.APP_NAME }}
+          tags: |
+            stable
+            ${{ needs.get-version.outputs.VERSION_TAG }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3.1.1
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: app/rquest-omop-agent/Dockerfile


### PR DESCRIPTION
## Overview

- Workflow to publish a timestamped docker image of the "one-shot" rquest omop agent
- Workflow for stable release of dockerised agent

## Azure Boards

- AB#94473
- AB#94474
