### PR TITLE
AB#98448: Remaining ROCrate Entities

### DIFF
--- a/lib/ROCrates.Net.Tests/TestDataset.cs
+++ b/lib/ROCrates.Net.Tests/TestDataset.cs
@@ -1,0 +1,61 @@
+using Xunit.Abstractions;
+
+namespace ROCrates.Tests;
+
+public class TestDataset : IDisposable
+{
+  private readonly ITestOutputHelper _testOutputHelper;
+  private static char _sep = Path.DirectorySeparatorChar;
+  private const string _testDirName = "my-test-file/";
+  private static readonly string _testBasePath = $"path{_sep}to{_sep}base";
+  
+  public TestDataset(ITestOutputHelper testOutputHelper)
+  {
+    _testOutputHelper = testOutputHelper;
+    Directory.CreateDirectory(_testBasePath);
+  }
+  
+  public void Dispose()
+  {
+    Directory.Delete(_testBasePath, recursive: true);
+  }
+  
+  [Fact]
+  public void TestWrite_Creates_Dir_From_Source()
+  {
+    var sourceDir = Path.Combine(_testBasePath, _testDirName);
+    Directory.CreateDirectory(sourceDir);
+    var dataset = new Models.Dataset(
+      new ROCrate(_testDirName),
+      source: Path.Combine(_testBasePath, _testDirName));
+    dataset.Write(_testBasePath);
+    Assert.True(Directory.Exists(Path.Combine(_testBasePath, sourceDir)));
+  }
+  
+  [Fact]
+  public void TestWrite_Creates_Dir_From_DestPath()
+  {
+    var sourceDir = Path.Combine(_testBasePath, _testDirName);
+    var destPath = Path.Combine(_testBasePath, "ext", _testDirName);
+    Directory.CreateDirectory(sourceDir);
+    Directory.CreateDirectory(destPath);
+    var dataset = new Models.Dataset(
+      new ROCrate(_testDirName),
+      source: Path.Combine(_testBasePath, _testDirName),
+      destPath: destPath);
+    dataset.Write(_testBasePath);
+    Assert.True(Directory.Exists(Path.Combine(_testBasePath, destPath)));
+  }
+  
+  [Fact]
+  public void TestWrite_Throws_When_SourceDir_DoesNotExist()
+  {
+    var testDestPath = Path.Combine(_testBasePath, "ext", _testDirName);
+    Directory.CreateDirectory(testDestPath);
+    var dataset = new Models.Dataset(
+      new ROCrate(_testDirName),
+      source: Path.Combine(_testBasePath, _testDirName),
+      destPath: testDestPath);
+    Assert.Throws<DirectoryNotFoundException>(() => dataset.Write(_testBasePath));
+  }
+}

--- a/lib/ROCrates.Net/Models/ComputationalWorkflow.cs
+++ b/lib/ROCrates.Net/Models/ComputationalWorkflow.cs
@@ -11,7 +11,7 @@ public class ComputationalWorkflow : File
   private protected string[] Types = { "File", "SoftwareSourceCode", "ComputationalWorkflow" };
   
   public ComputationalWorkflow(ROCrate crate, string? identifier = null, JsonObject? properties = null,
-    string source = "./", string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate,
+    string? source = null, string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate,
     identifier, properties, source, destPath, fetchRemote, validateUrl)
   {
     Properties = _empty();

--- a/lib/ROCrates.Net/Models/ComputationalWorkflow.cs
+++ b/lib/ROCrates.Net/Models/ComputationalWorkflow.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace ROCrates.Models;
+
+/// <summary>
+/// A scientific workflow that was used (or can be used) to analyze or generate files in the RO-Crate.
+/// </summary>
+public class ComputationalWorkflow : File
+{
+  private protected string[] Types = { "File", "SoftwareSourceCode", "ComputationalWorkflow" };
+  
+  public ComputationalWorkflow(ROCrate crate, string? identifier = null, JsonObject? properties = null,
+    string source = "./", string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate,
+    identifier, properties, source, destPath, fetchRemote, validateUrl)
+  {
+    Properties = _empty();
+    if (properties is not null) _unpackProperties(properties);
+    SetProperty("@type", Types);
+  }
+  
+  protected new JsonObject _empty()
+  {
+    var emptyJsonString = new Dictionary<string, string>
+    {
+      { "@id", Identifier },
+      { "@type", DefaultType },
+      { "name", Path.GetFileNameWithoutExtension(
+        Path.GetFileName(Identifier)) }
+    };
+    var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
+    return emptyObject;
+  }
+}

--- a/lib/ROCrates.Net/Models/ContextEntity.cs
+++ b/lib/ROCrates.Net/Models/ContextEntity.cs
@@ -8,7 +8,7 @@ public class ContextEntity : Entity
     identifier, properties)
   {
     Identifier = _formatIdentifier(Identifier);
-    if (properties is not null) _unpackPropterties(properties);
+    if (properties is not null) _unpackProperties(properties);
   }
 
   protected sealed override string _formatIdentifier(string identifier)

--- a/lib/ROCrates.Net/Models/ContextEntity.cs
+++ b/lib/ROCrates.Net/Models/ContextEntity.cs
@@ -8,6 +8,7 @@ public class ContextEntity : Entity
     identifier, properties)
   {
     Identifier = _formatIdentifier(Identifier);
+    if (properties is not null) _unpackPropterties(properties);
   }
 
   protected sealed override string _formatIdentifier(string identifier)

--- a/lib/ROCrates.Net/Models/ContextEntity.cs
+++ b/lib/ROCrates.Net/Models/ContextEntity.cs
@@ -7,5 +7,14 @@ public class ContextEntity : Entity
   public ContextEntity(ROCrate crate, string? identifier = null, JsonObject? properties = null) : base(crate,
     identifier, properties)
   {
+    Identifier = _formatIdentifier(Identifier);
+  }
+
+  protected sealed override string _formatIdentifier(string identifier)
+  {
+    if (Uri.IsWellFormedUriString(identifier, UriKind.RelativeOrAbsolute) || identifier.Contains('#'))
+      return identifier;
+    
+    return "#" + identifier;
   }
 }

--- a/lib/ROCrates.Net/Models/ContextEntity.cs
+++ b/lib/ROCrates.Net/Models/ContextEntity.cs
@@ -11,7 +11,7 @@ public class ContextEntity : Entity
     if (properties is not null) _unpackProperties(properties);
   }
 
-  protected sealed override string _formatIdentifier(string identifier)
+  private protected sealed override string _formatIdentifier(string identifier)
   {
     if (Uri.IsWellFormedUriString(identifier, UriKind.RelativeOrAbsolute) || identifier.Contains('#'))
       return identifier;

--- a/lib/ROCrates.Net/Models/DataEntity.cs
+++ b/lib/ROCrates.Net/Models/DataEntity.cs
@@ -8,4 +8,9 @@ public class DataEntity : Entity
     properties)
   {
   }
+
+  public virtual void Write(string basePath)
+  {
+    throw new NotImplementedException();
+  }
 }

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -15,8 +15,7 @@ public class Dataset : FileOrDir
 
   public override void Write(string basePath)
   {
-    var outFilePath = Path.Join(basePath, Identifier);
-    var outFileParent = Path.GetDirectoryName(outFilePath);
+    var outPath = Path.Join(basePath, Identifier);
     if (Uri.IsWellFormedUriString(_source, UriKind.Absolute))
     {
       if (_validateUrl && !_fetchRemote)
@@ -28,12 +27,14 @@ public class Dataset : FileOrDir
 
       if (_fetchRemote)
       {
-        _getParts(basePath);
+        _getParts(outPath);
       }
     }
     else
     {
       // Copy files on system
+      if (!Directory.Exists(_source)) throw new DirectoryNotFoundException($"{_source} does not exist.");
+      Directory.CreateDirectory(outPath);
     }
   }
 

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace ROCrates.Models;
@@ -11,6 +12,7 @@ public class Dataset : FileOrDir
   {
     DefaultType = "Dataset";
     Properties = _empty();
+    if (properties is not null) _unpackPropterties(properties);
     Identifier = _formatIdentifier(Identifier);
   }
 
@@ -80,6 +82,18 @@ public class Dataset : FileOrDir
     }
   }
 
+  protected new JsonObject _empty()
+  {
+    var emptyJsonString = new Dictionary<string, string>
+    {
+      { "@id", Identifier },
+      { "@type", DefaultType },
+      { "datePublished", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture) }
+    };
+    var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
+    return emptyObject;
+  }
+
   protected sealed override string _formatIdentifier(string identifier)
   {
     var newId =  identifier.TrimEnd(Path.DirectorySeparatorChar);
@@ -87,4 +101,6 @@ public class Dataset : FileOrDir
     newId += "/";
     return newId;
   }
+  
+  
 }

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -11,6 +11,7 @@ public class Dataset : FileOrDir
   {
     DefaultType = "Dataset";
     Properties = _empty();
+    Identifier = _formatIdentifier(Identifier);
   }
 
   /// <summary>
@@ -77,5 +78,13 @@ public class Dataset : FileOrDir
       using var file = System.IO.File.OpenWrite(partOutPath);
       httpStream.CopyTo(file);
     }
+  }
+
+  protected sealed override string _formatIdentifier(string identifier)
+  {
+    var newId =  identifier.TrimEnd(Path.DirectorySeparatorChar);
+    newId = newId.TrimEnd(Path.AltDirectorySeparatorChar);
+    newId += "/";
+    return newId;
   }
 }

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -13,6 +13,28 @@ public class Dataset : FileOrDir
     Properties = _empty();
   }
 
+  /// <summary>
+  /// <para>Write the contents of a <c>Dataset</c> to disk.</para>
+  /// <para>If the <c>Dataset</c>'s source is remote, the contents will be downloaded to <c>basePath</c>.</para>
+  /// <para>If the source is on disk, the contents will be copied under <c>basePath</c>.</para>
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// var url = "https://hdruk.github.io/hutch/docs/devs";
+  /// var dirName = url.Split('/').Last();
+  /// var dataset = new Models.Dataset(
+  ///    new ROCrate("myCrate.zip"),
+  ///    source: url,
+  ///    validateUrl: true,
+  ///    fetchRemote: true);
+  /// dataset.Write("myCrate");
+  /// Assert.True(Directory.Exists(Path.Combine("myCrate", dirName)));
+  /// </code>
+  /// </example>
+  /// <param name="basePath">The path under which the <c>Dataset</c>'s parts will be written.</param>
+  /// <exception cref="DirectoryNotFoundException">
+  /// Thrown when the source directory is not a URL, but it doesn't exist.
+  /// </exception>
   public override void Write(string basePath)
   {
     var outPath = Path.Join(basePath, Identifier);
@@ -32,7 +54,6 @@ public class Dataset : FileOrDir
     }
     else
     {
-      // Copy files on system
       if (!Directory.Exists(_source)) throw new DirectoryNotFoundException($"{_source} does not exist.");
       Directory.CreateDirectory(outPath);
     }

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -94,7 +94,7 @@ public class Dataset : FileOrDir
     return emptyObject;
   }
 
-  protected sealed override string _formatIdentifier(string identifier)
+  private protected sealed override string _formatIdentifier(string identifier)
   {
     var newId =  identifier.TrimEnd(Path.DirectorySeparatorChar);
     newId = newId.TrimEnd(Path.AltDirectorySeparatorChar);

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -16,6 +16,7 @@ public class Dataset : FileOrDir
   public override void Write(string basePath)
   {
     var outFilePath = Path.Join(basePath, Identifier);
+    var outFileParent = Path.GetDirectoryName(outFilePath);
     if (Uri.IsWellFormedUriString(_source, UriKind.Absolute))
     {
       if (_validateUrl && !_fetchRemote)
@@ -27,13 +28,32 @@ public class Dataset : FileOrDir
 
       if (_fetchRemote)
       {
-        
+        _getParts(basePath);
       }
+    }
+    else
+    {
+      // Copy files on system
     }
   }
 
   private void _getParts(string outPath)
   {
-    
+    Directory.CreateDirectory(outPath);
+    var basePath = _source.TrimEnd('/');
+    var parts = GetProperty<Dictionary<string, string>>("hasPart");
+    if (parts is null) return;
+    using var httpClient = new HttpClient();
+    foreach (var p in parts)
+    {
+      var part = p.Key == "@id" ? p.Value : null;
+      if (part is null) continue;
+      var partUri = $"{basePath}/{part}";
+      var partOutPath = Path.Combine(outPath, part);
+      var response = httpClient.GetAsync(partUri).Result.Content;
+      using var httpStream = response.ReadAsStream();
+      using var file = System.IO.File.OpenWrite(partOutPath);
+      httpStream.CopyTo(file);
+    }
   }
 }

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -6,7 +6,7 @@ namespace ROCrates.Models;
 
 public class Dataset : FileOrDir
 {
-  public Dataset(ROCrate crate, string? identifier = null, JsonObject? properties = null, string source = "./",
+  public Dataset(ROCrate crate, string? identifier = null, JsonObject? properties = null, string? source = null,
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
     source, destPath, fetchRemote, validateUrl)
   {

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -12,7 +12,7 @@ public class Dataset : FileOrDir
   {
     DefaultType = "Dataset";
     Properties = _empty();
-    if (properties is not null) _unpackPropterties(properties);
+    if (properties is not null) _unpackProperties(properties);
     Identifier = _formatIdentifier(Identifier);
   }
 

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using System.Text.Json.Nodes;
+
+namespace ROCrates.Models;
+
+public class Dataset : FileOrDir
+{
+  public Dataset(ROCrate crate, string? identifier = null, JsonObject? properties = null, string source = "./",
+    string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
+    source, destPath, fetchRemote, validateUrl)
+  {
+    DefaultType = "Dataset";
+    Properties = _empty();
+  }
+
+  public override void Write(string basePath)
+  {
+    var outFilePath = Path.Join(basePath, Identifier);
+    if (Uri.IsWellFormedUriString(_source, UriKind.Absolute))
+    {
+      if (_validateUrl && !_fetchRemote)
+      {
+        using HttpClient client = new HttpClient();
+        var response = client.GetAsync(_source).Result.Content;
+        SetProperty("sdDatePublished", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture));
+      }
+
+      if (_fetchRemote)
+      {
+        
+      }
+    }
+  }
+
+  private void _getParts(string outPath)
+  {
+    
+  }
+}

--- a/lib/ROCrates.Net/Models/Entity.cs
+++ b/lib/ROCrates.Net/Models/Entity.cs
@@ -19,7 +19,7 @@ public class Entity
     RoCrate = crate;
     if (identifier is not null) Identifier = identifier;
     Properties = _empty();
-    if (properties is not null) _unpackPropterties(properties);
+    if (properties is not null) _unpackProperties(properties);
   }
 
   /// <summary>
@@ -97,7 +97,7 @@ public class Entity
     return identifier;
   }
 
-  protected void _unpackPropterties(JsonObject props)
+  protected void _unpackProperties(JsonObject props)
   {
     using var propsEnumerator = props.GetEnumerator();
     while (propsEnumerator.MoveNext())

--- a/lib/ROCrates.Net/Models/Entity.cs
+++ b/lib/ROCrates.Net/Models/Entity.cs
@@ -8,7 +8,7 @@ namespace ROCrates.Models;
 /// </summary>
 public class Entity
 {
-  protected string DefaultType = "Thing";
+  private protected string DefaultType = "Thing";
   public ROCrate RoCrate { get; set; }
   public string Identifier { get; set; } = Guid.NewGuid().ToString();
 
@@ -80,7 +80,7 @@ public class Entity
     Properties.Remove(propertyName);
   }
 
-  protected JsonObject _empty()
+  private protected JsonObject _empty()
   {
     var emptyJsonString = new Dictionary<string, string>
     {
@@ -91,12 +91,12 @@ public class Entity
     return emptyObject;
   }
 
-  protected virtual string _formatIdentifier(string identifier)
+  private protected virtual string _formatIdentifier(string identifier)
   {
     return identifier;
   }
 
-  protected void _unpackProperties(JsonObject props)
+  private protected void _unpackProperties(JsonObject props)
   {
     using var propsEnumerator = props.GetEnumerator();
     while (propsEnumerator.MoveNext())

--- a/lib/ROCrates.Net/Models/Entity.cs
+++ b/lib/ROCrates.Net/Models/Entity.cs
@@ -17,17 +17,9 @@ public class Entity
   public Entity(ROCrate crate, string? identifier = null, JsonObject? properties = null)
   {
     RoCrate = crate;
-    if (identifier != null) Identifier = identifier;
+    if (identifier is not null) Identifier = identifier;
     Properties = _empty();
-    if (properties != null)
-    {
-      using var propsEnumerator = properties.GetEnumerator();
-      while (propsEnumerator.MoveNext())
-      {
-        var (key, value) = propsEnumerator.Current;
-        if (value != null) SetProperty(key, value);
-      }
-    }
+    if (properties is not null) _unpackPropterties(properties);
   }
 
   /// <summary>
@@ -103,5 +95,15 @@ public class Entity
   protected virtual string _formatIdentifier(string identifier)
   {
     return identifier;
+  }
+
+  protected void _unpackPropterties(JsonObject props)
+  {
+    using var propsEnumerator = props.GetEnumerator();
+    while (propsEnumerator.MoveNext())
+    {
+      var (key, value) = propsEnumerator.Current;
+      if (value != null) SetProperty(key, value);
+    }
   }
 }

--- a/lib/ROCrates.Net/Models/Entity.cs
+++ b/lib/ROCrates.Net/Models/Entity.cs
@@ -8,7 +8,7 @@ namespace ROCrates.Models;
 /// </summary>
 public class Entity
 {
-  private const string _defaultType = "Thing";
+  protected string DefaultType = "Thing";
   public ROCrate RoCrate { get; set; }
   public string Identifier { get; set; } = Guid.NewGuid().ToString();
 
@@ -89,12 +89,12 @@ public class Entity
     Properties.Remove(propertyName);
   }
 
-  private JsonObject _empty()
+  protected JsonObject _empty()
   {
     var emptyJsonString = new Dictionary<string, string>
     {
       { "@id", Identifier },
-      { "@type", _defaultType }
+      { "@type", DefaultType }
     };
     var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
     return emptyObject;

--- a/lib/ROCrates.Net/Models/Entity.cs
+++ b/lib/ROCrates.Net/Models/Entity.cs
@@ -99,4 +99,9 @@ public class Entity
     var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
     return emptyObject;
   }
+
+  protected virtual string _formatIdentifier(string identifier)
+  {
+    return identifier;
+  }
 }

--- a/lib/ROCrates.Net/Models/Entity.cs
+++ b/lib/ROCrates.Net/Models/Entity.cs
@@ -43,9 +43,8 @@ public class Entity
   /// </returns>
   public T? GetProperty<T>(string propertyName)
   {
-    T? deserialisedProperty;
     Properties.TryGetPropertyValue(propertyName, out var property);
-    deserialisedProperty = property.Deserialize<T>();
+    var deserialisedProperty = property.Deserialize<T>();
     return deserialisedProperty;
   }
 

--- a/lib/ROCrates.Net/Models/File.cs
+++ b/lib/ROCrates.Net/Models/File.cs
@@ -15,7 +15,7 @@ public class File : FileOrDir
   {
     DefaultType = "File";
     Properties = _empty();
-    if (properties is not null) _unpackPropterties(properties);
+    if (properties is not null) _unpackProperties(properties);
   }
 
   /// <summary>

--- a/lib/ROCrates.Net/Models/File.cs
+++ b/lib/ROCrates.Net/Models/File.cs
@@ -9,22 +9,12 @@ namespace ROCrates.Models;
 /// </summary>
 public class File : FileOrDir
 {
-  private const string _defaultType = "File";
-
   public File(ROCrate crate, string? identifier = null, JsonObject? properties = null, string source = "./",
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
     source, destPath, fetchRemote, validateUrl)
   {
+    DefaultType = "File";
     Properties = _empty();
-    if (properties != null)
-    {
-      using var propsEnumerator = properties.GetEnumerator();
-      while (propsEnumerator.MoveNext())
-      {
-        var (key, value) = propsEnumerator.Current;
-        if (value != null) SetProperty(key, value);
-      }
-    }
   }
 
   /// <summary>
@@ -83,16 +73,5 @@ public class File : FileOrDir
       Directory.CreateDirectory(outFileParent);
       System.IO.File.Copy(_source, outFilePath, overwrite: true);
     }
-  }
-
-  private JsonObject _empty()
-  {
-    var emptyJsonString = new Dictionary<string, string>
-    {
-      { "@id", Identifier },
-      { "@type", _defaultType }
-    };
-    var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
-    return emptyObject;
   }
 }

--- a/lib/ROCrates.Net/Models/File.cs
+++ b/lib/ROCrates.Net/Models/File.cs
@@ -44,7 +44,7 @@ public class File : FileOrDir
   /// </code>
   /// </example>
   /// <param name="basePath">The path the file will be written to.</param>
-  public void Write(string basePath)
+  public override void Write(string basePath)
   {
     var outFilePath = Path.Join(basePath, Identifier);
     var outFileParent = Path.GetDirectoryName(outFilePath);

--- a/lib/ROCrates.Net/Models/File.cs
+++ b/lib/ROCrates.Net/Models/File.cs
@@ -15,6 +15,7 @@ public class File : FileOrDir
   {
     DefaultType = "File";
     Properties = _empty();
+    if (properties is not null) _unpackPropterties(properties);
   }
 
   /// <summary>

--- a/lib/ROCrates.Net/Models/File.cs
+++ b/lib/ROCrates.Net/Models/File.cs
@@ -9,7 +9,7 @@ namespace ROCrates.Models;
 /// </summary>
 public class File : FileOrDir
 {
-  public File(ROCrate crate, string? identifier = null, JsonObject? properties = null, string source = "./",
+  public File(ROCrate crate, string? identifier = null, JsonObject? properties = null, string? source = null,
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
     source, destPath, fetchRemote, validateUrl)
   {
@@ -59,7 +59,7 @@ public class File : FileOrDir
       {
         SetProperty("contentSize", response.Headers.ContentLength);
         SetProperty("encodingFormat", response.Headers.ContentType);
-        if (!_fetchRemote) 
+        if (!_fetchRemote)
           SetProperty("sdDatePublished", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture));
       }
 

--- a/lib/ROCrates.Net/Models/FileOrDir.cs
+++ b/lib/ROCrates.Net/Models/FileOrDir.cs
@@ -8,10 +8,10 @@ public class FileOrDir : DataEntity
   protected string? _destPath;
   protected bool _fetchRemote;
   protected bool _validateUrl;
-  public FileOrDir(ROCrate crate, string? identifier = null, JsonObject? properties = null, string source = "./",
+  public FileOrDir(ROCrate crate, string? identifier = null, JsonObject? properties = null, string? source = null,
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties)
   {
-    _source = source;
+    _source = source ?? "./";
     _destPath = destPath;
     _fetchRemote = fetchRemote;
     _validateUrl = validateUrl;

--- a/lib/ROCrates.Net/Models/Metadata.cs
+++ b/lib/ROCrates.Net/Models/Metadata.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace ROCrates.Models;
+
+/// <summary>
+/// RO-Crate Metadata file.
+/// </summary>
+public class Metadata : File
+{
+  protected const string BaseName = "ro-crate-metadata.json";
+  protected const string Profile = "https://w3id.org/ro/crate/1.1";
+
+  public RootDataset RootDataset; // { get {RoCrate.RootDataset()} } // Todo: getter returns crate root dataset.
+  
+  public Metadata(ROCrate crate, string? identifier = null, JsonObject? properties = null, string? source = null,
+    string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
+    source, destPath, fetchRemote, validateUrl)
+  {
+    DefaultType = "CreativeWork";
+    Properties = _empty();
+    if (properties is not null) _unpackProperties(properties);
+    SetProperty("conformsTo", new Dictionary<string, string>{{"@id", Profile}});
+    SetProperty("about", new Dictionary<string, string>{{"@id", "./"}});
+    Identifier = source ?? destPath ?? BaseName;
+  }
+
+  private JsonObject _generate()
+  {
+    // Iterate through the entities in the RO-Crate, extract their properties and serialise to JSON.
+    throw new NotImplementedException();
+  }
+
+  public override void Write(string basePath)
+  {
+    var outPath = Path.Combine(basePath, Identifier);
+    var metadataJson = _generate();
+    System.IO.File.WriteAllText(outPath, metadataJson.ToString());
+  }
+}

--- a/lib/ROCrates.Net/Models/Metadata.cs
+++ b/lib/ROCrates.Net/Models/Metadata.cs
@@ -11,8 +11,8 @@ public class Metadata : File
   protected const string BaseName = "ro-crate-metadata.json";
   protected const string Profile = "https://w3id.org/ro/crate/1.1";
 
-  public RootDataset RootDataset; // { get {RoCrate.RootDataset()} } // Todo: getter returns crate root dataset.
-  
+  public RootDataset? RootDataset => RoCrate.RootDataset;
+
   public Metadata(ROCrate crate, string? identifier = null, JsonObject? properties = null, string? source = null,
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
     source, destPath, fetchRemote, validateUrl)

--- a/lib/ROCrates.Net/Models/Person.cs
+++ b/lib/ROCrates.Net/Models/Person.cs
@@ -5,22 +5,11 @@ namespace ROCrates.Models;
 
 public class Person : ContextEntity
 {
-  private const string _defaultType = "Person";
-  
   public Person(ROCrate crate, string? identifier = null, JsonObject? properties = null) : base(crate, identifier,
     properties)
   {
+    DefaultType = "Person";
     Properties = _empty();
-  }
-  
-  private JsonObject _empty()
-  {
-    var emptyJsonString = new Dictionary<string, string>
-    {
-      { "@id", Identifier },
-      { "@type", _defaultType }
-    };
-    var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
-    return emptyObject;
+    if (properties is not null) _unpackPropterties(properties);
   }
 }

--- a/lib/ROCrates.Net/Models/Person.cs
+++ b/lib/ROCrates.Net/Models/Person.cs
@@ -10,6 +10,6 @@ public class Person : ContextEntity
   {
     DefaultType = "Person";
     Properties = _empty();
-    if (properties is not null) _unpackPropterties(properties);
+    if (properties is not null) _unpackProperties(properties);
   }
 }

--- a/lib/ROCrates.Net/Models/Person.cs
+++ b/lib/ROCrates.Net/Models/Person.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace ROCrates.Models;
+
+public class Person : ContextEntity
+{
+  private const string _defaultType = "Person";
+  
+  public Person(ROCrate crate, string? identifier = null, JsonObject? properties = null) : base(crate, identifier,
+    properties)
+  {
+    Properties = _empty();
+  }
+  
+  private JsonObject _empty()
+  {
+    var emptyJsonString = new Dictionary<string, string>
+    {
+      { "@id", Identifier },
+      { "@type", _defaultType }
+    };
+    var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
+    return emptyObject;
+  }
+}

--- a/lib/ROCrates.Net/Models/RootDataset.cs
+++ b/lib/ROCrates.Net/Models/RootDataset.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Nodes;
+
+namespace ROCrates.Models;
+
+public class RootDataset : Dataset
+{
+  public RootDataset(ROCrate crate, string? identifier = null, JsonObject? properties = null, string source = "./",
+    string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
+    source, destPath, fetchRemote, validateUrl)
+  {
+    Properties = _empty();
+    if (properties is not null) _unpackPropterties(properties);
+  }
+}

--- a/lib/ROCrates.Net/Models/RootDataset.cs
+++ b/lib/ROCrates.Net/Models/RootDataset.cs
@@ -4,7 +4,7 @@ namespace ROCrates.Models;
 
 public class RootDataset : Dataset
 {
-  public RootDataset(ROCrate crate, string? identifier = null, JsonObject? properties = null, string source = "./",
+  public RootDataset(ROCrate crate, string? identifier = null, JsonObject? properties = null, string? source = null,
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
     source, destPath, fetchRemote, validateUrl)
   {

--- a/lib/ROCrates.Net/Models/RootDataset.cs
+++ b/lib/ROCrates.Net/Models/RootDataset.cs
@@ -9,6 +9,6 @@ public class RootDataset : Dataset
     source, destPath, fetchRemote, validateUrl)
   {
     Properties = _empty();
-    if (properties is not null) _unpackPropterties(properties);
+    if (properties is not null) _unpackProperties(properties);
   }
 }

--- a/lib/ROCrates.Net/Models/SoftwareApplication.cs
+++ b/lib/ROCrates.Net/Models/SoftwareApplication.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Nodes;
+
+namespace ROCrates.Models;
+
+public class SoftwareApplication : ContextEntity
+{
+  public SoftwareApplication(ROCrate crate, string? identifier = null, JsonObject? properties = null) : base(crate,
+    identifier, properties)
+  {
+    DefaultType = "SoftwareApplication";
+    Properties = _empty();
+    if (properties is not null) _unpackProperties(properties);
+  }
+}

--- a/lib/ROCrates.Net/Models/Workflow.cs
+++ b/lib/ROCrates.Net/Models/Workflow.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Nodes;
+
+namespace ROCrates.Models;
+
+/// <summary>
+/// Legacy workflow, added for completeness.
+/// </summary>
+public class Workflow : ComputationalWorkflow
+{
+  public Workflow(ROCrate crate, string? identifier = null, JsonObject? properties = null, string source = "./",
+    string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
+    source, destPath, fetchRemote, validateUrl)
+  {
+    Types = new []{ "File", "SoftwareSourceCode", "Workflow" };
+    SetProperty("@type", Types);
+  }
+}

--- a/lib/ROCrates.Net/Models/Workflow.cs
+++ b/lib/ROCrates.Net/Models/Workflow.cs
@@ -7,7 +7,7 @@ namespace ROCrates.Models;
 /// </summary>
 public class Workflow : ComputationalWorkflow
 {
-  public Workflow(ROCrate crate, string? identifier = null, JsonObject? properties = null, string source = "./",
+  public Workflow(ROCrate crate, string? identifier = null, JsonObject? properties = null, string? source = null,
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
     source, destPath, fetchRemote, validateUrl)
   {

--- a/lib/ROCrates.Net/Models/WorkflowDescription.cs
+++ b/lib/ROCrates.Net/Models/WorkflowDescription.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Nodes;
+
+namespace ROCrates.Models;
+
+/// <summary>
+/// Abstract CWL description of the main workflow.
+/// </summary>
+public class WorkflowDescription : ComputationalWorkflow
+{
+  public WorkflowDescription(ROCrate crate, string? identifier = null, JsonObject? properties = null,
+    string source = "./", string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate,
+    identifier, properties, source, destPath, fetchRemote, validateUrl)
+  {
+    Types = new[] { "File", "SoftwareSourceCode", "HowTo" };
+    SetProperty("@type", Types);
+  }
+}

--- a/lib/ROCrates.Net/Models/WorkflowDescription.cs
+++ b/lib/ROCrates.Net/Models/WorkflowDescription.cs
@@ -8,7 +8,7 @@ namespace ROCrates.Models;
 public class WorkflowDescription : ComputationalWorkflow
 {
   public WorkflowDescription(ROCrate crate, string? identifier = null, JsonObject? properties = null,
-    string source = "./", string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate,
+    string? source = null, string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate,
     identifier, properties, source, destPath, fetchRemote, validateUrl)
   {
     Types = new[] { "File", "SoftwareSourceCode", "HowTo" };

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -18,6 +18,8 @@ public class ROCrate
   private bool _generatePreview;
   private bool _init;
 
+  public RootDataset? RootDataset { get; set; }
+
   public ROCrate(string source, bool generatePreview = false, bool init = false, List<string>? exclude = null)
   {
     _source = source;


### PR DESCRIPTION
## Overview

Created the following entities for RO-Crates:
- Person
- Metadata
- Entity
  - FileOrDir
  - File
  - Dataset
  - RootDataset
  - ComputationalWorkFlow
  - Workflow
  - WorkflowDescription
  - SoftwareApplication

## Azure Boards

- AB#98468
- AB#98496
- AB#98579
- AB#98581
- AB#98582
- AB#98583
- AB#98597

## Notes

Models will need custom serialisation built. 

These entities are just a minimal set needed to finish building the main `ROCrate` class. Others like `TestSuite`, etc. will come later.
