### PR TITLE
AB#98445: ROCrate builder methods

### DIFF
--- a/lib/ROCrates.Net.Tests/TestEntity.cs
+++ b/lib/ROCrates.Net.Tests/TestEntity.cs
@@ -5,7 +5,7 @@ using Xunit.Abstractions;
 
 namespace ROCrates.Tests;
 
-public class TestRoCrateEntity
+public class TestEntity
 {
   [Fact]
   public void TestSetProperty_Updates()

--- a/lib/ROCrates.Net.Tests/TestEntity.cs
+++ b/lib/ROCrates.Net.Tests/TestEntity.cs
@@ -7,13 +7,16 @@ namespace ROCrates.Tests;
 
 public class TestEntity
 {
+  private ROCrate _roCrate = new();
+  private string _jsonLd =
+    "{\"@id\": \"./\",\"identifier\": \"https://doi.org/10.4225/59/59672c09f4a4b\",\"@type\": \"Dataset\", \"randomNumber\": 123, \"datePublished\": \"2017\",\"name\": \"Data files associated with the manuscript:Effects of facilitated family case conferencing for ...\",\"description\": \"Palliative care planning for nursing home residents with advanced dementia ...\",\"license\": {\"@id\": \"https://creativecommons.org/licenses/by-nc-sa/3.0/au/\"}}";
+
+  
   [Fact]
   public void TestSetProperty_Updates()
   {
-    var jsonLd =
-      "{\"@id\": \"./\",\"identifier\": \"https://doi.org/10.4225/59/59672c09f4a4b\",\"@type\": \"Dataset\",\"datePublished\": \"2017\",\"name\": \"Data files associated with the manuscript:Effects of facilitated family case conferencing for ...\",\"description\": \"Palliative care planning for nursing home residents with advanced dementia ...\",\"license\": {\"@id\": \"https://creativecommons.org/licenses/by-nc-sa/3.0/au/\"}}";
-    var jsonObject = JsonNode.Parse(jsonLd).AsObject();
-    var entity = new Entity(new ROCrate("my-test.zip"), properties: jsonObject);
+    var jsonObject = JsonNode.Parse(_jsonLd).AsObject();
+    var entity = new Entity(_roCrate, properties: jsonObject);
     var gotValue = entity.Properties.TryGetPropertyValue("datePublished", out var datePublished);
     Assert.True(gotValue);
     Assert.Equal("2017", datePublished.ToString());
@@ -25,10 +28,8 @@ public class TestEntity
   [Fact]
   public void TestGetProperty_CorrectTypes()
   {
-    var jsonLd =
-      "{\"randomNumber\": 123, \"@id\": \"./\",\"identifier\": \"https://doi.org/10.4225/59/59672c09f4a4b\",\"@type\": \"Dataset\",\"datePublished\": \"2017\",\"name\": \"Data files associated with the manuscript:Effects of facilitated family case conferencing for ...\",\"description\": \"Palliative care planning for nursing home residents with advanced dementia ...\",\"license\": {\"@id\": \"https://creativecommons.org/licenses/by-nc-sa/3.0/au/\"}}";
-    var jsonObject = JsonNode.Parse(jsonLd).AsObject();
-    var entity = new Entity(new ROCrate("my-test.zip"), properties: jsonObject);
+    var jsonObject = JsonNode.Parse(_jsonLd).AsObject();
+    var entity = new Entity(_roCrate, properties: jsonObject);
     var retrievedInt = entity.GetProperty<int>("randomNumber");
     Assert.IsType<int>(retrievedInt);
     Assert.Equal(123, retrievedInt);
@@ -41,8 +42,7 @@ public class TestEntity
   [Fact]
   public void TestDefaultProperties()
   {
-    var entity = new Entity(
-      new ROCrate("my-test.zip"));
+    var entity = new Entity(_roCrate);
     var gotValue = entity.Properties.TryGetPropertyValue("@type", out var type);
     Assert.True(gotValue);
     Assert.Equal("Thing", type.ToString());
@@ -51,14 +51,26 @@ public class TestEntity
   [Fact]
   public void TestProperties_Type_Is_AsSpecified()
   {
-    var jsonLd =
-      "{\"randomNumber\": 123, \"@id\": \"./\",\"identifier\": \"https://doi.org/10.4225/59/59672c09f4a4b\",\"@type\": \"Dataset\",\"datePublished\": \"2017\",\"name\": \"Data files associated with the manuscript:Effects of facilitated family case conferencing for ...\",\"description\": \"Palliative care planning for nursing home residents with advanced dementia ...\",\"license\": {\"@id\": \"https://creativecommons.org/licenses/by-nc-sa/3.0/au/\"}}";
-    var jsonObject = JsonNode.Parse(jsonLd).AsObject();
+    var jsonObject = JsonNode.Parse(_jsonLd).AsObject();
     var entity = new Entity(
-      new ROCrate("my-test.zip"),
+      _roCrate,
       properties: jsonObject);
     var gotValue = entity.Properties.TryGetPropertyValue("@type", out var type);
     Assert.True(gotValue);
     Assert.Equal("Dataset", type.ToString());
+  }
+
+  [Fact]
+  public void TestAppendTo_CreatesHasPart()
+  {
+    var jsonObject = JsonNode.Parse(_jsonLd).AsObject();
+    var entity = new Entity(_roCrate, properties: jsonObject);
+    var entity2 = new Entity(_roCrate);
+    entity.AppendTo("hasPart", entity2);
+    
+    Assert.True(entity.Properties.ContainsKey("hasPart"));
+    Assert.True(entity.Properties.TryGetPropertyValue("hasPart", out var outputIdJson));
+    var outputId = outputIdJson.Deserialize<Part>();
+    Assert.Equal(entity2.GetCanonicalId(), outputId.Identifier);
   }
 }

--- a/lib/ROCrates.Net.Tests/TestEntity.cs
+++ b/lib/ROCrates.Net.Tests/TestEntity.cs
@@ -61,16 +61,43 @@ public class TestEntity
   }
 
   [Fact]
-  public void TestAppendTo_CreatesHasPart()
+  public void TestAppendTo_CreatesKey()
   {
     var jsonObject = JsonNode.Parse(_jsonLd).AsObject();
     var entity = new Entity(_roCrate, properties: jsonObject);
     var entity2 = new Entity(_roCrate);
-    entity.AppendTo("hasPart", entity2);
     
+    Assert.False(entity.Properties.ContainsKey("hasPart"));
+    entity.AppendTo("hasPart", entity2);
     Assert.True(entity.Properties.ContainsKey("hasPart"));
+  }
+  
+  [Fact]
+  public void TestAppendTo_MakesSinglePart()
+  {
+    var jsonObject = JsonNode.Parse(_jsonLd).AsObject();
+    var entity = new Entity(_roCrate, properties: jsonObject);
+    var entity2 = new Entity(_roCrate);
+    
+    entity.AppendTo("hasPart", entity2);
     Assert.True(entity.Properties.TryGetPropertyValue("hasPart", out var outputIdJson));
     var outputId = outputIdJson.Deserialize<Part>();
     Assert.Equal(entity2.GetCanonicalId(), outputId.Identifier);
+  }
+  
+  [Fact]
+  public void TestAppendTo_AppendsToList()
+  {
+    var jsonObject = JsonNode.Parse(_jsonLd).AsObject();
+    var entity = new Entity(_roCrate, properties: jsonObject);
+    var entity2 = new Entity(_roCrate);
+    var entity3 = new Entity(_roCrate);
+    
+    entity.AppendTo("hasPart", entity2);
+    entity.AppendTo("hasPart", entity3);
+    
+    entity.Properties.TryGetPropertyValue("hasPart", out var outputIdJson);
+    var outputId = outputIdJson.Deserialize<List<Part>>();
+    Assert.Equal(2, outputId.Count);
   }
 }

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -48,12 +48,13 @@ public class TestRoCrate
     var roCrate = new ROCrate();
     var person = new Person(roCrate);
     var rootDataset = new RootDataset(roCrate);
+    var metedata = new Metadata(roCrate);
     var file = new File(roCrate);
-    Assert.Null(roCrate.RootDataset);
-    
-    roCrate.Add(person, rootDataset, file);
+
+    roCrate.Add(person, rootDataset, file, metedata);
     Assert.Equal(roCrate.RootDataset.Identifier, rootDataset.Identifier);
     Assert.IsType<RootDataset>(roCrate.RootDataset);
-    
+    Assert.Equal(roCrate.Metadata.Identifier, metedata.Identifier);
+    Assert.IsType<Metadata>(roCrate.Metadata);
   }
 }

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -42,19 +42,51 @@ public class TestRoCrate
     Assert.EndsWith(withSlash.TrimEnd('/'), resultWithSlash);
   }
 
+  
+  [Fact]
+  public void TestAdd_AddsRootDataset()
+  {
+    var roCrate = new ROCrate();
+    var rootDataset = new RootDataset(roCrate);
+
+    roCrate.Add(rootDataset);
+    Assert.Equal(roCrate.RootDataset.Identifier, rootDataset.Identifier);
+    Assert.Equal(roCrate.RootDataset.Properties, rootDataset.Properties);
+
+    Assert.True(roCrate.Entities.ContainsKey(rootDataset.GetCanonicalId()));
+    Assert.True(roCrate.Entities.TryGetValue(rootDataset.GetCanonicalId(), out var recoveredRootDataset));
+    Assert.IsType<RootDataset>(recoveredRootDataset);
+  }
+  
+  [Fact]
+  public void TestAdd_AddsMetadata()
+  {
+    var roCrate = new ROCrate();
+    var metadata = new Metadata(roCrate);
+
+    roCrate.Add(metadata);
+    Assert.Equal(roCrate.Metadata.Identifier, metadata.Identifier);
+    Assert.Equal(roCrate.Metadata.Properties, metadata.Properties);
+
+    Assert.True(roCrate.Entities.ContainsKey(metadata.GetCanonicalId()));
+    Assert.True(roCrate.Entities.TryGetValue(metadata.GetCanonicalId(), out var recoveredMetadata));
+    Assert.IsType<Metadata>(recoveredMetadata);
+  }
+  
   [Fact]
   public void TestAdd_AddsObjetsOfDifferentTypes()
   {
     var roCrate = new ROCrate();
     var person = new Person(roCrate);
     var rootDataset = new RootDataset(roCrate);
-    var metedata = new Metadata(roCrate);
-    var file = new File(roCrate);
+    var metadata = new Metadata(roCrate);
+    var file = new File(roCrate, source: "my-test-file.txt");
 
-    roCrate.Add(person, rootDataset, file, metedata);
+    roCrate.Add(person, rootDataset, file, metadata);
     Assert.Equal(roCrate.RootDataset.Identifier, rootDataset.Identifier);
+    Assert.Equal(roCrate.RootDataset.Properties, rootDataset.Properties);
     Assert.IsType<RootDataset>(roCrate.RootDataset);
-    Assert.Equal(roCrate.Metadata.Identifier, metedata.Identifier);
+    Assert.Equal(roCrate.Metadata.Identifier, metadata.Identifier);
     Assert.IsType<Metadata>(roCrate.Metadata);
   }
 }

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -1,7 +1,18 @@
+using ROCrates.Models;
+using Xunit.Abstractions;
+using File = ROCrates.Models.File;
+
 namespace ROCrates.Tests;
 
 public class TestRoCrate
 {
+  private readonly ITestOutputHelper _testOutputHelper;
+
+  public TestRoCrate(ITestOutputHelper testOutputHelper)
+  {
+    _testOutputHelper = testOutputHelper;
+  }
+
   [Fact]
   public void TestResolveId_CombinesGoodAndBad_Uris()
   {
@@ -29,5 +40,20 @@ public class TestRoCrate
     
     string resultWithSlash = crate.ResolveId(withSlash);
     Assert.EndsWith(withSlash.TrimEnd('/'), resultWithSlash);
+  }
+
+  [Fact]
+  public void TestAdd_AddsObjetsOfDifferentTypes()
+  {
+    var roCrate = new ROCrate();
+    var person = new Person(roCrate);
+    var rootDataset = new RootDataset(roCrate);
+    var file = new File(roCrate);
+    Assert.Null(roCrate.RootDataset);
+    
+    roCrate.Add(person, rootDataset, file);
+    Assert.Equal(roCrate.RootDataset.Identifier, rootDataset.Identifier);
+    Assert.IsType<RootDataset>(roCrate.RootDataset);
+    
   }
 }

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -78,15 +78,22 @@ public class TestRoCrate
   {
     var roCrate = new ROCrate();
     var person = new Person(roCrate);
-    var rootDataset = new RootDataset(roCrate);
-    var metadata = new Metadata(roCrate);
     var file = new File(roCrate, source: "my-test-file.txt");
+    var dataset = new Dataset(roCrate, source: "my-data-dir/");
 
-    roCrate.Add(person, rootDataset, file, metadata);
-    Assert.Equal(roCrate.RootDataset.Identifier, rootDataset.Identifier);
-    Assert.Equal(roCrate.RootDataset.Properties, rootDataset.Properties);
-    Assert.IsType<RootDataset>(roCrate.RootDataset);
-    Assert.Equal(roCrate.Metadata.Identifier, metadata.Identifier);
-    Assert.IsType<Metadata>(roCrate.Metadata);
+    roCrate.Add(person, file, dataset);
+
+    Assert.True(roCrate.Entities.ContainsKey(person.GetCanonicalId()));
+    Assert.True(roCrate.Entities.TryGetValue(person.GetCanonicalId(), out var recoveredPerson));
+    Assert.IsType<Person>(recoveredPerson);
+    
+    Assert.True(roCrate.Entities.ContainsKey(file.GetCanonicalId()));
+    Assert.True(roCrate.Entities.TryGetValue(file.GetCanonicalId(), out var recoveredFile));
+    Assert.IsType<File>(recoveredFile);
+    
+    Assert.True(roCrate.Entities.ContainsKey(dataset.GetCanonicalId()));
+    Assert.True(roCrate.Entities.TryGetValue(dataset.GetCanonicalId(), out var recoveredDataset));
+    Assert.IsType<Dataset>(recoveredDataset);
+    
   }
 }

--- a/lib/ROCrates.Net/Models/Entity.cs
+++ b/lib/ROCrates.Net/Models/Entity.cs
@@ -93,13 +93,24 @@ public class Entity
   {
     if (key.StartsWith('@')) throw new Exception($"Cannot append to {key}");
     if (value is null) throw new NullReferenceException("value cannot be null.");
+    
     var newItem = new Part { Identifier = value.GetCanonicalId() };
     var itemList = new List<Part>{ newItem };
+    
     if (Properties.TryGetPropertyValue(key, out var propsJson))
     {
-      var currentItems = propsJson.Deserialize<List<Part>>() ?? new List<Part>();
-      if (currentItems.Count > 0) itemList.InsertRange(0, currentItems);
+      var currentItem = propsJson.Deserialize<Part>();
+      if (currentItem is null)
+      {
+        var currentItems = propsJson.Deserialize<List<Part>>() ?? new List<Part>();
+        if (currentItems.Count > 0) itemList.InsertRange(0, currentItems);
+      }
+      else
+      {
+        itemList.Insert(0, currentItem);
+      }
     }
+    
     if (itemList.Count > 1) SetProperty(key, itemList);
     else SetProperty(key, newItem);
   }

--- a/lib/ROCrates.Net/Models/Entity.cs
+++ b/lib/ROCrates.Net/Models/Entity.cs
@@ -72,6 +72,39 @@ public class Entity
   }
 
   /// <summary>
+  /// Append a value to the entity's property.
+  /// </summary>
+  /// <param name="key">The element to append the value to.</param>
+  /// <param name="value">The value to be appended.</param>
+  /// <typeparam name="T">The type of <c>Entity</c> to be appended.</typeparam>
+  /// <exception cref="Exception">
+  /// Thrown when attempting to append to reserved key (those starting with '@').
+  /// </exception>
+  /// <exception cref="NullReferenceException">Thrown when <c>value</c> is <c>null</c>.</exception>
+  /// <example>
+  /// <code>
+  /// var roCrate = new ROCrate();
+  /// var rootDataset = new RootDataset(roCrate);
+  /// var person = new Person(roCrate, identifier: "Alice");
+  /// rootDataset.AppendTo("author", person);
+  /// </code>
+  /// </example>
+  public void AppendTo<T>(string key, T value) where T : Entity
+  {
+    if (key.StartsWith('@')) throw new Exception($"Cannot append to {key}");
+    if (value is null) throw new NullReferenceException("value cannot be null.");
+    var newItem = new Part { Identifier = value.GetCanonicalId() };
+    var itemList = new List<Part>{ newItem };
+    if (Properties.TryGetPropertyValue(key, out var propsJson))
+    {
+      var currentItems = propsJson.Deserialize<List<Part>>() ?? new List<Part>();
+      if (currentItems.Count > 0) itemList.InsertRange(0, currentItems);
+    }
+    if (itemList.Count > 1) SetProperty(key, itemList);
+    else SetProperty(key, newItem);
+  }
+
+  /// <summary>
   /// Remove a property from the <c>Properties</c> field.
   /// </summary>
   /// <param name="propertyName"></param>

--- a/lib/ROCrates.Net/Models/Part.cs
+++ b/lib/ROCrates.Net/Models/Part.cs
@@ -1,0 +1,10 @@
+namespace ROCrates.Models;
+
+/// <summary>
+/// Represents an "ID tag" linking a property to an object one object in an RO-Crate to another.
+/// </summary>
+public class Part
+{
+  public const string Key = "@id";
+  public string Identifier { get; set; } = string.Empty;
+}

--- a/lib/ROCrates.Net/Models/Part.cs
+++ b/lib/ROCrates.Net/Models/Part.cs
@@ -1,7 +1,7 @@
 namespace ROCrates.Models;
 
 /// <summary>
-/// Represents an "ID tag" linking a property to an object one object in an RO-Crate to another.
+/// Represents an "ID tag" linking a property in one object in an RO-Crate to another object in the same crate.
 /// </summary>
 public class Part
 {

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
+using System.Text.Json.Nodes;
 using ROCrates.Models;
 using File = ROCrates.Models.File;
 
@@ -106,5 +107,30 @@ public class ROCrate
   public void AddPerson(Person person)
   {
     Add(person);
+  }
+
+  /// <summary>
+  /// Add a file to the RO-Crate and return the created <c>File</c> object.
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// var roCrate = new ROCrate();
+  /// var textFile = new File(roCrate, source: "my-file.txt");
+  /// var file = roCrate.AddFile(textFile);
+  /// </code>
+  /// </example>
+  /// <param name="identifier">The unique identifier.</param>
+  /// <param name="properties">Additional properties of the file.</param>
+  /// <param name="source">The path to the file.</param>
+  /// <param name="destPath">The path to where file will be saved.</param>
+  /// <param name="fetchRemote">Fetch the file from remote location?</param>
+  /// <param name="validateUrl">Check the URL?</param>
+  /// <returns>A new <c>File</c> with the given parameter.</returns>
+  public File AddFile(string? identifier = null, JsonObject? properties = null, string? source = null,
+    string? destPath = null, bool fetchRemote = false, bool validateUrl = false)
+  {
+    var file = new File(this, identifier, properties, source, destPath, fetchRemote, validateUrl);
+    Add(file);
+    return file;
   }
 }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -94,7 +94,7 @@ public class ROCrate
   }
 
   /// <summary>
-  /// Add a person to the RO-Crate.
+  /// Add a person to the RO-Crate and return the created <c>Person</c> object.
   /// </summary>
   /// <example>
   /// <code>
@@ -104,6 +104,7 @@ public class ROCrate
   /// </example>
   /// <param name="identifier">The unique identifier of the person.</param>
   /// <param name="properties">Additional properties of the person.</param>
+  /// <remarks>A new <c>Person</c> with the given parameters.</remarks>
   public Person AddPerson(string? identifier = null, JsonObject? properties = null)
   {
     var person = new Person(this, identifier, properties);
@@ -126,7 +127,7 @@ public class ROCrate
   /// <param name="destPath">The path to where file will be saved.</param>
   /// <param name="fetchRemote">Fetch the file from remote location?</param>
   /// <param name="validateUrl">Check the URL?</param>
-  /// <returns>A new <c>File</c> with the given parameter.</returns>
+  /// <returns>A new <c>File</c> with the given parameters.</returns>
   public File AddFile(string? identifier = null, JsonObject? properties = null, string? source = null,
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false)
   {
@@ -150,7 +151,7 @@ public class ROCrate
   /// <param name="destPath">The path to where dataset will be saved.</param>
   /// <param name="fetchRemote">Fetch the dataset from remote location?</param>
   /// <param name="validateUrl">Check the URL?</param>
-  /// <returns>A new <c>Dataset</c> with the given parameter.</returns>
+  /// <returns>A new <c>Dataset</c> with the given parameters.</returns>
   public Dataset AddDataset(string? identifier = null, JsonObject? properties = null, string? source = null,
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false)
   {

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -5,6 +5,7 @@ using ROCrates.Models;
 using File = ROCrates.Models.File;
 
 namespace ROCrates;
+
 public class ROCrate
 {
   private List<ContextEntity> _contextEntities = new();
@@ -12,10 +13,11 @@ public class ROCrate
   private List<Entity> _defaultEntities = new();
   private static string _uuid = Guid.NewGuid().ToString();
   private string _arcpBaseUri = $"arcp://uuid,{_uuid}/";
+
   /// TODO: add the following fields:
   ///   - preview (based on Preview class not yet made)
-
   private string _source = string.Empty;
+
   private List<string> _exclude = new();
   private bool _generatePreview;
   private bool _init;
@@ -23,7 +25,7 @@ public class ROCrate
   public RootDataset RootDataset;
 
   public Metadata Metadata;
-  
+
   public Dictionary<string, Entity> Entities = new();
 
   /// <summary>
@@ -81,14 +83,17 @@ public class ROCrate
       {
         RootDataset = entity as RootDataset;
       }
+
       if (entityType == typeof(Metadata))
       {
         Metadata = entity as Metadata;
       }
+
       if (entityType.IsSubclassOf(typeof(DataEntity)))
       {
         if (!Entities.ContainsKey(key)) RootDataset.AppendTo("hasPart", entity);
       }
+
       Entities.Add(key, entity);
     }
   }
@@ -135,7 +140,7 @@ public class ROCrate
     Add(file);
     return file;
   }
-  
+
   /// <summary>
   /// Add a dataset to the RO-Crate and return the created <c>Dataset</c> object.
   /// </summary>
@@ -158,5 +163,28 @@ public class ROCrate
     var dataset = new Dataset(this, identifier, properties, source, destPath, fetchRemote, validateUrl);
     Add(dataset);
     return dataset;
+  }
+
+  /// <summary>
+  /// Add a workflow to the RO-Crate and return the created <c>ComputationalWorkflow</c> object.
+  /// </summary>
+  /// <param name="identifier"></param>
+  /// <param name="properties"></param>
+  /// <param name="source"></param>
+  /// <param name="destPath"></param>
+  /// <param name="fetchRemote"></param>
+  /// <param name="validateUrl"></param>
+  /// <returns>A new <c>ComputationalWorkflow</c> with the given parameters.</returns>
+  public ComputationalWorkflow AddWorkflow(string? identifier = null, JsonObject? properties = null,
+    string? source = null, string? destPath = null, bool fetchRemote = false, bool validateUrl = false)
+  {
+    var workflow = new ComputationalWorkflow(this, identifier, properties, source, destPath, fetchRemote, validateUrl);
+    
+    var profiles = Metadata.GetProperty<List<Part>>("conformsTo") ?? new List<Part>();
+    profiles.Add(new Part { Identifier = "https://w3id.org/workflowhub/workflow-ro-crate/1.0" });
+    Metadata.SetProperty("conformsTo", profiles);
+
+    Add(workflow);
+    return workflow;
   }
 }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -134,4 +134,28 @@ public class ROCrate
     Add(file);
     return file;
   }
+  
+  /// <summary>
+  /// Add a dataset to the RO-Crate and return the created <c>Dataset</c> object.
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// var roCrate = new ROCrate();
+  /// var dataset = roCrate.AddDataset();
+  /// </code>
+  /// </example>
+  /// <param name="identifier">The unique identifier.</param>
+  /// <param name="properties">Additional properties of the dataset.</param>
+  /// <param name="source">The path to the dataset.</param>
+  /// <param name="destPath">The path to where dataset will be saved.</param>
+  /// <param name="fetchRemote">Fetch the dataset from remote location?</param>
+  /// <param name="validateUrl">Check the URL?</param>
+  /// <returns>A new <c>Dataset</c> with the given parameter.</returns>
+  public Dataset AddDataset(string? identifier = null, JsonObject? properties = null, string? source = null,
+    string? destPath = null, bool fetchRemote = false, bool validateUrl = false)
+  {
+    var dataset = new Dataset(this, identifier, properties, source, destPath, fetchRemote, validateUrl);
+    Add(dataset);
+    return dataset;
+  }
 }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -65,7 +65,7 @@ public class ROCrate
   /// var roCrate = new ROCrate();
   /// var textFile = new File(roCrate, source: "my-file.txt");
   /// var imageFile = new File(roCrate, source: "my-image.png");
-  /// var person = new Person();
+  /// var person = new Person(roCrate);
   /// roCrate.Add(textFile, imageFile, person);
   /// </code>
   /// </example>
@@ -90,5 +90,21 @@ public class ROCrate
       }
       Entities.Add(key, entity);
     }
+  }
+
+  /// <summary>
+  /// Add a person to the RO-Crate.
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// var roCrate = new ROCrate();
+  /// var person = new Person(roCrate);
+  /// roCrate.AddPerson(person);
+  /// </code>
+  /// </example>
+  /// <param name="person">The person to add to the RO-Crate.</param>
+  public void AddPerson(Person person)
+  {
+    Add(person);
   }
 }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -13,17 +13,24 @@ public class ROCrate
   /// TODO: add the following fields:
   ///   - preview (based on Preview class not yet made)
 
-  private string _source;
-  private List<string>? _exclude;
+  private string _source = string.Empty;
+  private List<string> _exclude = new();
   private bool _generatePreview;
   private bool _init;
+
+  /// <summary>
+  /// Initialise a new empty <c>ROCrate</c> object. This constructor will not create or parse an RO-Crate on disk.
+  /// </summary>
+  public ROCrate()
+  {
+  }
 
   public ROCrate(string source, bool generatePreview = false, bool init = false, List<string>? exclude = null)
   {
     _source = source;
     _generatePreview = generatePreview;
     _init = init;
-    _exclude = exclude;
+    if (exclude is not null) _exclude = exclude;
   }
 
   /// <summary>

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -80,6 +80,10 @@ public class ROCrate
       {
         Metadata = entity as Metadata;
       }
+      if (entityType.IsSubclassOf(typeof(DataEntity)))
+      {
+        // TODO: handle adding to "hasPart" of RootDataset
+      }
       Entities.Add(key, entity);
     }
   }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -21,6 +21,8 @@ public class ROCrate
   private bool _init;
 
   public RootDataset? RootDataset { get; set; }
+  
+  public Metadata? Metadata { get; set; }
 
   /// <summary>
   /// Initialise a new empty <c>ROCrate</c> object. This constructor will not create or parse an RO-Crate on disk.
@@ -67,11 +69,19 @@ public class ROCrate
   {
     foreach (var entity in entities)
     {
+      var entityType = entity.GetType();
       var key = entity.GetCanonicalId();
-      if (entity.GetType() == typeof(RootDataset))
+      if (entityType == typeof(RootDataset))
       {
         RootDataset = entity as RootDataset;
+        _entityMap.Add(key, entity as RootDataset);
       }
+      if (entityType == typeof(Metadata))
+      {
+        Metadata = entity as Metadata;
+        _entityMap.Add(key, entity as Metadata);
+      }
+      // TODO: handle adding preview
     }
   }
 }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -168,6 +168,12 @@ public class ROCrate
   /// <summary>
   /// Add a workflow to the RO-Crate and return the created <c>ComputationalWorkflow</c> object.
   /// </summary>
+  /// <example>
+  /// <code>
+  /// var roCrate = new ROCrate();
+  /// var workflow = roCrate.AddWorkflow();
+  /// </code>
+  /// </example>
   /// <param name="identifier">The unique identifier.</param>
   /// <param name="properties">Additional properties of the workflow.</param>
   /// <param name="source">The path to the workflow file.</param>

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -99,14 +99,16 @@ public class ROCrate
   /// <example>
   /// <code>
   /// var roCrate = new ROCrate();
-  /// var person = new Person(roCrate);
-  /// roCrate.AddPerson(person);
+  /// var person = roCrate.AddPerson();
   /// </code>
   /// </example>
-  /// <param name="person">The person to add to the RO-Crate.</param>
-  public void AddPerson(Person person)
+  /// <param name="identifier">The unique identifier of the person.</param>
+  /// <param name="properties">Additional properties of the person.</param>
+  public Person AddPerson(string? identifier = null, JsonObject? properties = null)
   {
+    var person = new Person(this, identifier, properties);
     Add(person);
+    return person;
   }
 
   /// <summary>
@@ -115,8 +117,7 @@ public class ROCrate
   /// <example>
   /// <code>
   /// var roCrate = new ROCrate();
-  /// var textFile = new File(roCrate, source: "my-file.txt");
-  /// var file = roCrate.AddFile(textFile);
+  /// var file = roCrate.AddFile();
   /// </code>
   /// </example>
   /// <param name="identifier">The unique identifier.</param>

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -7,7 +7,7 @@ namespace ROCrates;
 public class ROCrate
 {
   private List<ContextEntity> _contextEntities = new();
-  private List<FileOrDir> _dataEntities = new();
+  private List<DataEntity> _dataEntities = new();
   private List<Entity> _defaultEntities = new();
   private Dictionary<string, Entity> _entityMap = new();
   private static string _uuid = Guid.NewGuid().ToString();
@@ -65,5 +65,13 @@ public class ROCrate
   /// <param name="entities">The entities to add the the <c>ROCrate</c>.</param>
   public void Add(params Entity[] entities)
   {
+    foreach (var entity in entities)
+    {
+      var key = entity.GetCanonicalId();
+      if (entity.GetType() == typeof(RootDataset))
+      {
+        RootDataset = entity as RootDataset;
+      }
+    }
   }
 }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -168,12 +168,12 @@ public class ROCrate
   /// <summary>
   /// Add a workflow to the RO-Crate and return the created <c>ComputationalWorkflow</c> object.
   /// </summary>
-  /// <param name="identifier"></param>
-  /// <param name="properties"></param>
-  /// <param name="source"></param>
-  /// <param name="destPath"></param>
-  /// <param name="fetchRemote"></param>
-  /// <param name="validateUrl"></param>
+  /// <param name="identifier">The unique identifier.</param>
+  /// <param name="properties">Additional properties of the workflow.</param>
+  /// <param name="source">The path to the workflow file.</param>
+  /// <param name="destPath">The path to where workflow file will be saved.</param>
+  /// <param name="fetchRemote">Fetch the workflow from remote location?</param>
+  /// <param name="validateUrl">Check the URL?</param>
   /// <returns>A new <c>ComputationalWorkflow</c> with the given parameters.</returns>
   public ComputationalWorkflow AddWorkflow(string? identifier = null, JsonObject? properties = null,
     string? source = null, string? destPath = null, bool fetchRemote = false, bool validateUrl = false)

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -9,7 +9,6 @@ public class ROCrate
   private List<ContextEntity> _contextEntities = new();
   private List<DataEntity> _dataEntities = new();
   private List<Entity> _defaultEntities = new();
-  private Dictionary<string, Entity> _entityMap = new();
   private static string _uuid = Guid.NewGuid().ToString();
   private string _arcpBaseUri = $"arcp://uuid,{_uuid}/";
   /// TODO: add the following fields:
@@ -23,6 +22,8 @@ public class ROCrate
   public RootDataset? RootDataset { get; set; }
   
   public Metadata? Metadata { get; set; }
+  
+  public Dictionary<string, Entity> Entities = new();
 
   /// <summary>
   /// Initialise a new empty <c>ROCrate</c> object. This constructor will not create or parse an RO-Crate on disk.
@@ -74,14 +75,12 @@ public class ROCrate
       if (entityType == typeof(RootDataset))
       {
         RootDataset = entity as RootDataset;
-        _entityMap.Add(key, entity as RootDataset);
       }
       if (entityType == typeof(Metadata))
       {
         Metadata = entity as Metadata;
-        _entityMap.Add(key, entity as Metadata);
       }
-      // TODO: handle adding preview
+      Entities.Add(key, entity);
     }
   }
 }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -19,9 +19,9 @@ public class ROCrate
   private bool _generatePreview;
   private bool _init;
 
-  public RootDataset? RootDataset { get; set; }
-  
-  public Metadata? Metadata { get; set; }
+  public RootDataset RootDataset;
+
+  public Metadata Metadata;
   
   public Dictionary<string, Entity> Entities = new();
 
@@ -30,6 +30,8 @@ public class ROCrate
   /// </summary>
   public ROCrate()
   {
+    RootDataset = new RootDataset(this);
+    Metadata = new Metadata(this);
   }
 
   public ROCrate(string source, bool generatePreview = false, bool init = false, List<string>? exclude = null)
@@ -38,6 +40,8 @@ public class ROCrate
     _generatePreview = generatePreview;
     _init = init;
     if (exclude is not null) _exclude = exclude;
+    RootDataset = new RootDataset(this);
+    Metadata = new Metadata(this);
   }
 
   /// <summary>
@@ -82,7 +86,7 @@ public class ROCrate
       }
       if (entityType.IsSubclassOf(typeof(DataEntity)))
       {
-        // TODO: handle adding to "hasPart" of RootDataset
+        if (!Entities.ContainsKey(key)) RootDataset.AppendTo("hasPart", entity);
       }
       Entities.Add(key, entity);
     }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -1,5 +1,7 @@
-﻿using System.Text.Encodings.Web;
+﻿using System.Runtime.CompilerServices;
+using System.Text.Encodings.Web;
 using ROCrates.Models;
+using File = ROCrates.Models.File;
 
 namespace ROCrates;
 public class ROCrate
@@ -44,5 +46,22 @@ public class ROCrate
 
     var resolvedId = Path.Combine(_arcpBaseUri, id);
     return resolvedId.TrimEnd('/');
+  }
+
+  /// <summary>
+  /// Add entities to an <c>ROCrate</c>.
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// var roCrate = new ROCrate();
+  /// var textFile = new File(roCrate, source: "my-file.txt");
+  /// var imageFile = new File(roCrate, source: "my-image.png");
+  /// var person = new Person();
+  /// roCrate.Add(textFile, imageFile, person);
+  /// </code>
+  /// </example>
+  /// <param name="entities">The entities to add the the <c>ROCrate</c>.</param>
+  public void Add(params Entity[] entities)
+  {
   }
 }


### PR DESCRIPTION
## Overview

Add generic `Add` method to `ROCrate.cs` which can add any Entity subclass.
Add builder methods to `ROCrate.cs` for `Person`, `Dataset`, `ComputationalWorkflow` and `File`.

## Azure Boards

- AB#98455
- AB#98596
- AB#98457
- AB#98456
- AB#98895
- AB#98453
