### PR TITLE
AB#99610: File and Dataset test suites still occasionally fail

### DIFF
--- a/lib/ROCrates.Net.Tests/TestDataset.cs
+++ b/lib/ROCrates.Net.Tests/TestDataset.cs
@@ -1,5 +1,3 @@
-using Xunit.Abstractions;
-
 namespace ROCrates.Tests;
 
 public class TestDataset : IClassFixture<TestDatasetFixture>
@@ -23,7 +21,7 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
     dataset.Write(_testDatasetFixture.TestBasePath);
     Assert.True(Directory.Exists(Path.Combine(_testDatasetFixture.TestBasePath, sourceDir)));
   }
-  
+
   [Fact]
   public void TestWrite_Creates_Dir_From_DestPath()
   {
@@ -38,7 +36,7 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
     dataset.Write(_testDatasetFixture.TestBasePath);
     Assert.True(Directory.Exists(Path.Combine(_testDatasetFixture.TestBasePath, destPath)));
   }
-  
+
   [Fact]
   public void TestWrite_Throws_When_SourceDir_DoesNotExist()
   {
@@ -55,11 +53,12 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
 public class TestDatasetFixture : IDisposable
 {
   public readonly string TestBasePath = Path.Combine("dataset", "test", "path");
-  
+
   public TestDatasetFixture()
   {
     Directory.CreateDirectory(TestBasePath);
   }
+
   public void Dispose()
   {
     Directory.Delete(TestBasePath, recursive: true);

--- a/lib/ROCrates.Net.Tests/TestDataset.cs
+++ b/lib/ROCrates.Net.Tests/TestDataset.cs
@@ -13,18 +13,24 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
   [Fact]
   public void TestWrite_Creates_Dir_From_Source()
   {
+    // Arrange
     var sourceDir = Path.Combine(_testDatasetFixture.TestBasePath, _testDirName);
     Directory.CreateDirectory(sourceDir);
     var dataset = new Models.Dataset(
       new ROCrate(_testDirName),
       source: Path.Combine(_testDatasetFixture.TestBasePath, _testDirName));
+
+    // Act
     dataset.Write(_testDatasetFixture.TestBasePath);
+
+    // Assert
     Assert.True(Directory.Exists(Path.Combine(_testDatasetFixture.TestBasePath, sourceDir)));
   }
 
   [Fact]
   public void TestWrite_Creates_Dir_From_DestPath()
   {
+    // Arrange
     var sourceDir = Path.Combine(_testDatasetFixture.TestBasePath, _testDirName);
     var destPath = Path.Combine(_testDatasetFixture.TestBasePath, "ext", _testDirName);
     Directory.CreateDirectory(sourceDir);
@@ -33,20 +39,30 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
       new ROCrate(_testDirName),
       source: Path.Combine(_testDatasetFixture.TestBasePath, _testDirName),
       destPath: destPath);
+
+    // Act
     dataset.Write(_testDatasetFixture.TestBasePath);
+
+    // Assert
     Assert.True(Directory.Exists(Path.Combine(_testDatasetFixture.TestBasePath, destPath)));
   }
 
   [Fact]
   public void TestWrite_Throws_When_SourceDir_DoesNotExist()
   {
+    // Arrange
     var testDestPath = Path.Combine(_testDatasetFixture.TestBasePath, "ext", _testDirName);
     Directory.CreateDirectory(testDestPath);
     var dataset = new Models.Dataset(
       new ROCrate(_testDirName),
       source: Path.Combine("non", "existent"),
       destPath: testDestPath);
-    Assert.Throws<DirectoryNotFoundException>(() => dataset.Write(_testDatasetFixture.TestBasePath));
+
+    // Act
+    var throwingFunc = () => dataset.Write(_testDatasetFixture.TestBasePath);
+
+    // Assert
+    Assert.Throws<DirectoryNotFoundException>(throwingFunc);
   }
 }
 

--- a/lib/ROCrates.Net.Tests/TestDataset.cs
+++ b/lib/ROCrates.Net.Tests/TestDataset.cs
@@ -4,69 +4,64 @@ namespace ROCrates.Tests;
 
 public class TestDataset : IClassFixture<TestDatasetFixture>
 {
-  private readonly ITestOutputHelper _testOutputHelper;
   private TestDatasetFixture _testDatasetFixture;
-  private static char _sep = Path.DirectorySeparatorChar;
-  private const string _testDirName = "my-test-file/";
-  private static readonly string _testBasePath = $"path{_sep}to{_sep}base";
-  
-  public TestDataset(ITestOutputHelper testOutputHelper, TestDatasetFixture testDatasetFixture)
+  private const string _testDirName = "my-test-dir/";
+
+  public TestDataset(TestDatasetFixture testDatasetFixture)
   {
-    _testOutputHelper = testOutputHelper;
     _testDatasetFixture = testDatasetFixture;
   }
 
   [Fact]
   public void TestWrite_Creates_Dir_From_Source()
   {
-    var sourceDir = Path.Combine(_testBasePath, _testDirName);
+    var sourceDir = Path.Combine(_testDatasetFixture.TestBasePath, _testDirName);
     Directory.CreateDirectory(sourceDir);
     var dataset = new Models.Dataset(
       new ROCrate(_testDirName),
-      source: Path.Combine(_testBasePath, _testDirName));
-    dataset.Write(_testBasePath);
-    Assert.True(Directory.Exists(Path.Combine(_testBasePath, sourceDir)));
+      source: Path.Combine(_testDatasetFixture.TestBasePath, _testDirName));
+    dataset.Write(_testDatasetFixture.TestBasePath);
+    Assert.True(Directory.Exists(Path.Combine(_testDatasetFixture.TestBasePath, sourceDir)));
   }
   
   [Fact]
   public void TestWrite_Creates_Dir_From_DestPath()
   {
-    var sourceDir = Path.Combine(_testBasePath, _testDirName);
-    var destPath = Path.Combine(_testBasePath, "ext", _testDirName);
+    var sourceDir = Path.Combine(_testDatasetFixture.TestBasePath, _testDirName);
+    var destPath = Path.Combine(_testDatasetFixture.TestBasePath, "ext", _testDirName);
     Directory.CreateDirectory(sourceDir);
     Directory.CreateDirectory(destPath);
     var dataset = new Models.Dataset(
       new ROCrate(_testDirName),
-      source: Path.Combine(_testBasePath, _testDirName),
+      source: Path.Combine(_testDatasetFixture.TestBasePath, _testDirName),
       destPath: destPath);
-    dataset.Write(_testBasePath);
-    Assert.True(Directory.Exists(Path.Combine(_testBasePath, destPath)));
+    dataset.Write(_testDatasetFixture.TestBasePath);
+    Assert.True(Directory.Exists(Path.Combine(_testDatasetFixture.TestBasePath, destPath)));
   }
   
   [Fact]
   public void TestWrite_Throws_When_SourceDir_DoesNotExist()
   {
-    var testDestPath = Path.Combine(_testBasePath, "ext", _testDirName);
+    var testDestPath = Path.Combine(_testDatasetFixture.TestBasePath, "ext", _testDirName);
     Directory.CreateDirectory(testDestPath);
     var dataset = new Models.Dataset(
       new ROCrate(_testDirName),
       source: Path.Combine("non", "existent"),
       destPath: testDestPath);
-    Assert.Throws<DirectoryNotFoundException>(() => dataset.Write(_testBasePath));
+    Assert.Throws<DirectoryNotFoundException>(() => dataset.Write(_testDatasetFixture.TestBasePath));
   }
 }
 
 public class TestDatasetFixture : IDisposable
 {
-  private static char _sep = Path.DirectorySeparatorChar;
-  private static readonly string _testBasePath = $"path{_sep}to{_sep}base";
+  public readonly string TestBasePath = Path.Combine("dataset", "test", "path");
   
   public TestDatasetFixture()
   {
-    Directory.CreateDirectory(_testBasePath);
+    Directory.CreateDirectory(TestBasePath);
   }
   public void Dispose()
   {
-    Directory.Delete(_testBasePath, recursive: true);
+    Directory.Delete(TestBasePath, recursive: true);
   }
 }

--- a/lib/ROCrates.Net.Tests/TestFile.cs
+++ b/lib/ROCrates.Net.Tests/TestFile.cs
@@ -6,14 +6,14 @@ public class TestFile : IClassFixture<TestFileFixture>
 {
   private readonly ITestOutputHelper _testOutputHelper;
   private TestFileFixture _testFileFixture;
-  private static char _sep = Path.DirectorySeparatorChar;
   private const string _testFileName = "my-test-file.txt";
-  private static readonly string _testBasePath = $"path{_sep}to{_sep}base";
+  private readonly string _testBasePath;
 
   public TestFile(ITestOutputHelper testOutputHelper, TestFileFixture testFileFixture)
   {
     _testOutputHelper = testOutputHelper;
     _testFileFixture = testFileFixture;
+    _testBasePath = testFileFixture.TestBasePath;
   }
 
   [Fact]
@@ -56,18 +56,18 @@ public class TestFile : IClassFixture<TestFileFixture>
 public class TestFileFixture : IDisposable
 {
   private static char _sep = Path.DirectorySeparatorChar;
-  private const string _testFileName = "my-test-file.txt";
-  private static readonly string _testBasePath = $"path{_sep}to{_sep}base";
+  public const string TestFileName = "my-test-file.txt";
+  public readonly string TestBasePath = Path.Combine("file", "test", "path");
   public TestFileFixture()
   {
-    Directory.CreateDirectory(_testBasePath);
-    using var file = new StreamWriter(Path.Combine(_testBasePath, _testFileName));
+    Directory.CreateDirectory(TestBasePath);
+    using var file = new StreamWriter(Path.Combine(TestBasePath, TestFileName));
     file.WriteLine("some content");
   }
   public void Dispose()
   {
-    File.Delete(_testFileName);
-    var rootDir = _testBasePath.Split(Path.DirectorySeparatorChar).First();
+    File.Delete(TestFileName);
+    var rootDir = TestBasePath.Split(Path.DirectorySeparatorChar).First();
     Directory.Delete(rootDir, recursive: true);
   }
 }

--- a/lib/ROCrates.Net.Tests/TestFile.cs
+++ b/lib/ROCrates.Net.Tests/TestFile.cs
@@ -1,17 +1,12 @@
-using Xunit.Abstractions;
-
 namespace ROCrates.Tests;
 
 public class TestFile : IClassFixture<TestFileFixture>
 {
-  private readonly ITestOutputHelper _testOutputHelper;
-  private TestFileFixture _testFileFixture;
-  private const string _testFileName = "my-test-file.txt";
+  private readonly TestFileFixture _testFileFixture;
   private readonly string _testBasePath;
 
-  public TestFile(ITestOutputHelper testOutputHelper, TestFileFixture testFileFixture)
+  public TestFile(TestFileFixture testFileFixture)
   {
-    _testOutputHelper = testOutputHelper;
     _testFileFixture = testFileFixture;
     _testBasePath = testFileFixture.TestBasePath;
   }
@@ -19,10 +14,10 @@ public class TestFile : IClassFixture<TestFileFixture>
   [Fact]
   public void TestWrite_Saves_To_DestPath()
   {
-    var testDestPath = Path.Combine(_testBasePath, "ext", _testFileName);
+    var testDestPath = Path.Combine(_testBasePath, "ext", _testFileFixture.TestFileName);
     var fileEntity = new Models.File(
-      new ROCrate(_testFileName),
-      source: Path.Combine(_testBasePath, _testFileName),
+      new ROCrate(_testFileFixture.TestFileName),
+      source: Path.Combine(_testBasePath, _testFileFixture.TestFileName),
       destPath: testDestPath);
     fileEntity.Write(_testBasePath);
     Assert.True(File.Exists(Path.Combine(_testBasePath, testDestPath)));
@@ -32,10 +27,10 @@ public class TestFile : IClassFixture<TestFileFixture>
   public void TestWrite_Saves_To_Source()
   {
     var fileEntity = new Models.File(
-      new ROCrate(_testFileName),
-      source: Path.Combine(_testBasePath, _testFileName));
+      new ROCrate(_testFileFixture.TestFileName),
+      source: Path.Combine(_testBasePath, _testFileFixture.TestFileName));
     fileEntity.Write(_testBasePath);
-    Assert.True(File.Exists(Path.Combine(_testBasePath, _testFileName)));
+    Assert.True(File.Exists(Path.Combine(_testBasePath, _testFileFixture.TestFileName)));
   }
   
   [Fact]
@@ -44,7 +39,7 @@ public class TestFile : IClassFixture<TestFileFixture>
     var url = "https://hdruk.github.io/hutch/docs/devs";
     var fileName = url.Split('/').Last();
     var fileEntity = new Models.File(
-      new ROCrate(_testFileName),
+      new ROCrate(_testFileFixture.TestFileName),
       source: url,
       validateUrl: true,
       fetchRemote: true);
@@ -55,8 +50,7 @@ public class TestFile : IClassFixture<TestFileFixture>
 
 public class TestFileFixture : IDisposable
 {
-  private static char _sep = Path.DirectorySeparatorChar;
-  public const string TestFileName = "my-test-file.txt";
+  public readonly string TestFileName = "my-test-file.txt";
   public readonly string TestBasePath = Path.Combine("file", "test", "path");
   public TestFileFixture()
   {

--- a/lib/ROCrates.Net.Tests/TestFile.cs
+++ b/lib/ROCrates.Net.Tests/TestFile.cs
@@ -14,28 +14,39 @@ public class TestFile : IClassFixture<TestFileFixture>
   [Fact]
   public void TestWrite_Saves_To_DestPath()
   {
+    // Arrange
     var testDestPath = Path.Combine(_testBasePath, "ext", _testFileFixture.TestFileName);
     var fileEntity = new Models.File(
       new ROCrate(_testFileFixture.TestFileName),
       source: Path.Combine(_testBasePath, _testFileFixture.TestFileName),
       destPath: testDestPath);
+
+    // Act
     fileEntity.Write(_testBasePath);
+
+    // Assert
     Assert.True(File.Exists(Path.Combine(_testBasePath, testDestPath)));
   }
-  
+
   [Fact]
   public void TestWrite_Saves_To_Source()
   {
+    // Arrange
     var fileEntity = new Models.File(
       new ROCrate(_testFileFixture.TestFileName),
       source: Path.Combine(_testBasePath, _testFileFixture.TestFileName));
+
+    // Act
     fileEntity.Write(_testBasePath);
+
+    // Assert
     Assert.True(File.Exists(Path.Combine(_testBasePath, _testFileFixture.TestFileName)));
   }
-  
+
   [Fact]
   public void TestWrite_Saves_From_Remote()
   {
+    // Arrange
     var url = "https://hdruk.github.io/hutch/docs/devs";
     var fileName = url.Split('/').Last();
     var fileEntity = new Models.File(
@@ -43,7 +54,11 @@ public class TestFile : IClassFixture<TestFileFixture>
       source: url,
       validateUrl: true,
       fetchRemote: true);
+
+    // Act
     fileEntity.Write(_testBasePath);
+
+    // Assert
     Assert.True(File.Exists(Path.Combine(_testBasePath, fileName)));
   }
 }
@@ -52,12 +67,14 @@ public class TestFileFixture : IDisposable
 {
   public readonly string TestFileName = "my-test-file.txt";
   public readonly string TestBasePath = Path.Combine("file", "test", "path");
+
   public TestFileFixture()
   {
     Directory.CreateDirectory(TestBasePath);
     using var file = new StreamWriter(Path.Combine(TestBasePath, TestFileName));
     file.WriteLine("some content");
   }
+
   public void Dispose()
   {
     File.Delete(TestFileName);


### PR DESCRIPTION
## Overview

Fix a similar bug to #164 and #163. When running all tests, path clashes still caused the tests to unexpectedly fail to to path collision in chosen test base paths. Paths no longer collide.

## Azure Boards

- AB#99652
- AB#99656
