### PR TITLE
AB#99486: this.Identifier is different to this.Id in entities. Create Id field

### DIFF
--- a/lib/ROCrates.Net.Tests/TestFileOrDir.cs
+++ b/lib/ROCrates.Net.Tests/TestFileOrDir.cs
@@ -25,9 +25,9 @@ public class TestFileOrDir
   {
     var dataEntity = new FileOrDir(
       new ROCrate("my-test.zip"));
-    Assert.Equal("./", dataEntity.Identifier);
+    Assert.Equal("./", dataEntity.Id);
   }
-  
+
   [Fact]
   public void Test_Identifier_Is_FileNameOnly()
   {
@@ -35,13 +35,13 @@ public class TestFileOrDir
     var dataEntity = new FileOrDir(
       new ROCrate("my-test.zip"),
       source: "./path/to/my-file.txt");
-    Assert.Equal("my-file", dataEntity.Identifier);
-    
+    Assert.Equal("my-file", dataEntity.Id);
+
     // remote source
     dataEntity = new FileOrDir(
       new ROCrate("my-test.zip"),
       source: "ftp:///path/to/my-file.txt",
       fetchRemote: true);
-    Assert.Equal("my-file", dataEntity.Identifier);
+    Assert.Equal("my-file", dataEntity.Id);
   }
 }

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -19,10 +19,10 @@ public class TestRoCrate
     string validUrl = "https://doi.org/10.4225/59/59672c09f4a4b";
     string invalidUrl = "htps/doi.org/10.4225/59/59672c09f4a4b";
     var crate = new ROCrate("my-test.zip");
-    
+
     string resultValidUrl = crate.ResolveId(validUrl);
-    Assert.Equal(validUrl,resultValidUrl);
-    
+    Assert.Equal(validUrl, resultValidUrl);
+
     string resultInvalidUrl = crate.ResolveId(invalidUrl);
     Assert.StartsWith("arcp://", resultInvalidUrl);
     Assert.EndsWith(invalidUrl, resultInvalidUrl);
@@ -34,15 +34,15 @@ public class TestRoCrate
     string noSlash = "https://doi.org/10.4225/59/59672c09f4a4b";
     string withSlash = noSlash + '/';
     var crate = new ROCrate("my-test.zip");
-    
+
     string resultNoSlash = crate.ResolveId(noSlash);
-    Assert.Equal(noSlash,resultNoSlash);
-    
+    Assert.Equal(noSlash, resultNoSlash);
+
     string resultWithSlash = crate.ResolveId(withSlash);
     Assert.EndsWith(withSlash.TrimEnd('/'), resultWithSlash);
   }
 
-  
+
   [Fact]
   public void TestAdd_AddsRootDataset()
   {
@@ -50,14 +50,14 @@ public class TestRoCrate
     var rootDataset = new RootDataset(roCrate);
 
     roCrate.Add(rootDataset);
-    Assert.Equal(roCrate.RootDataset.Identifier, rootDataset.Identifier);
+    Assert.Equal(roCrate.RootDataset.Id, rootDataset.Id);
     Assert.Equal(roCrate.RootDataset.Properties, rootDataset.Properties);
 
     Assert.True(roCrate.Entities.ContainsKey(rootDataset.GetCanonicalId()));
     Assert.True(roCrate.Entities.TryGetValue(rootDataset.GetCanonicalId(), out var recoveredRootDataset));
     Assert.IsType<RootDataset>(recoveredRootDataset);
   }
-  
+
   [Fact]
   public void TestAdd_AddsMetadata()
   {
@@ -65,14 +65,14 @@ public class TestRoCrate
     var metadata = new Metadata(roCrate);
 
     roCrate.Add(metadata);
-    Assert.Equal(roCrate.Metadata.Identifier, metadata.Identifier);
+    Assert.Equal(roCrate.Metadata.Id, metadata.Id);
     Assert.Equal(roCrate.Metadata.Properties, metadata.Properties);
 
     Assert.True(roCrate.Entities.ContainsKey(metadata.GetCanonicalId()));
     Assert.True(roCrate.Entities.TryGetValue(metadata.GetCanonicalId(), out var recoveredMetadata));
     Assert.IsType<Metadata>(recoveredMetadata);
   }
-  
+
   [Fact]
   public void TestAdd_AddsObjetsOfDifferentTypes()
   {
@@ -86,14 +86,13 @@ public class TestRoCrate
     Assert.True(roCrate.Entities.ContainsKey(person.GetCanonicalId()));
     Assert.True(roCrate.Entities.TryGetValue(person.GetCanonicalId(), out var recoveredPerson));
     Assert.IsType<Person>(recoveredPerson);
-    
+
     Assert.True(roCrate.Entities.ContainsKey(file.GetCanonicalId()));
     Assert.True(roCrate.Entities.TryGetValue(file.GetCanonicalId(), out var recoveredFile));
     Assert.IsType<File>(recoveredFile);
-    
+
     Assert.True(roCrate.Entities.ContainsKey(dataset.GetCanonicalId()));
     Assert.True(roCrate.Entities.TryGetValue(dataset.GetCanonicalId(), out var recoveredDataset));
     Assert.IsType<Dataset>(recoveredDataset);
-    
   }
 }

--- a/lib/ROCrates.Net/Models/ComputationalWorkflow.cs
+++ b/lib/ROCrates.Net/Models/ComputationalWorkflow.cs
@@ -9,7 +9,7 @@ namespace ROCrates.Models;
 public class ComputationalWorkflow : File
 {
   private protected string[] Types = { "File", "SoftwareSourceCode", "ComputationalWorkflow" };
-  
+
   public ComputationalWorkflow(ROCrate crate, string? identifier = null, JsonObject? properties = null,
     string? source = null, string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate,
     identifier, properties, source, destPath, fetchRemote, validateUrl)
@@ -18,15 +18,17 @@ public class ComputationalWorkflow : File
     if (properties is not null) _unpackProperties(properties);
     SetProperty("@type", Types);
   }
-  
+
   protected new JsonObject _empty()
   {
     var emptyJsonString = new Dictionary<string, string>
     {
-      { "@id", Identifier },
+      { "@id", Id },
       { "@type", DefaultType },
-      { "name", Path.GetFileNameWithoutExtension(
-        Path.GetFileName(Identifier)) }
+      {
+        "name", Path.GetFileNameWithoutExtension(
+          Path.GetFileName(Id))
+      }
     };
     var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
     return emptyObject;

--- a/lib/ROCrates.Net/Models/ComputerLanguage.cs
+++ b/lib/ROCrates.Net/Models/ComputerLanguage.cs
@@ -11,19 +11,19 @@ public class ComputerLanguage : ContextEntity
     Properties = _empty();
     if (properties is not null) _unpackProperties(properties);
   }
-  
+
   public string? Name
   {
     get => GetProperty<string>("name");
     set => SetProperty("name", value);
   }
-  
+
   public string? Url
   {
     get => GetProperty<string>("url");
     set => SetProperty("url", value);
   }
-  
+
   public string? AlternativeName
   {
     get => GetProperty<string>("alternativeName");
@@ -34,5 +34,11 @@ public class ComputerLanguage : ContextEntity
   {
     get => GetProperty<string>("version");
     set => SetProperty("version", value);
+  }
+
+  public string? Identifier
+  {
+    get => GetProperty<string>("identifier");
+    set => SetProperty("identifier", value);
   }
 }

--- a/lib/ROCrates.Net/Models/ContextEntity.cs
+++ b/lib/ROCrates.Net/Models/ContextEntity.cs
@@ -7,7 +7,7 @@ public class ContextEntity : Entity
   public ContextEntity(ROCrate crate, string? identifier = null, JsonObject? properties = null) : base(crate,
     identifier, properties)
   {
-    Identifier = _formatIdentifier(Identifier);
+    Id = _formatIdentifier(Id);
     if (properties is not null) _unpackProperties(properties);
   }
 
@@ -15,7 +15,7 @@ public class ContextEntity : Entity
   {
     if (Uri.IsWellFormedUriString(identifier, UriKind.RelativeOrAbsolute) || identifier.Contains('#'))
       return identifier;
-    
+
     return "#" + identifier;
   }
 }

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -13,7 +13,7 @@ public class Dataset : FileOrDir
     DefaultType = "Dataset";
     Properties = _empty();
     if (properties is not null) _unpackProperties(properties);
-    Identifier = _formatIdentifier(Identifier);
+    Id = _formatIdentifier(Id);
   }
 
   /// <summary>
@@ -40,7 +40,7 @@ public class Dataset : FileOrDir
   /// </exception>
   public override void Write(string basePath)
   {
-    var outPath = Path.Join(basePath, Identifier);
+    var outPath = Path.Join(basePath, Id);
     if (Uri.IsWellFormedUriString(_source, UriKind.Absolute))
     {
       if (_validateUrl && !_fetchRemote)
@@ -86,7 +86,7 @@ public class Dataset : FileOrDir
   {
     var emptyJsonString = new Dictionary<string, string>
     {
-      { "@id", Identifier },
+      { "@id", Id },
       { "@type", DefaultType },
       { "datePublished", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture) }
     };
@@ -96,11 +96,9 @@ public class Dataset : FileOrDir
 
   private protected sealed override string _formatIdentifier(string identifier)
   {
-    var newId =  identifier.TrimEnd(Path.DirectorySeparatorChar);
+    var newId = identifier.TrimEnd(Path.DirectorySeparatorChar);
     newId = newId.TrimEnd(Path.AltDirectorySeparatorChar);
     newId += "/";
     return newId;
   }
-  
-  
 }

--- a/lib/ROCrates.Net/Models/Entity.cs
+++ b/lib/ROCrates.Net/Models/Entity.cs
@@ -10,14 +10,19 @@ public class Entity
 {
   private protected string DefaultType = "Thing";
   public ROCrate RoCrate { get; set; }
-  public string Identifier { get; set; } = Guid.NewGuid().ToString();
+
+  public string Id
+  {
+    get => GetProperty<string>("@id");
+    set => SetProperty("@id", value);
+  }
 
   public JsonObject Properties { get; set; }
 
   public Entity(ROCrate crate, string? identifier = null, JsonObject? properties = null)
   {
     RoCrate = crate;
-    if (identifier is not null) Identifier = identifier;
+    Id = identifier ?? Guid.NewGuid().ToString();
     Properties = _empty();
     if (properties is not null) _unpackProperties(properties);
   }
@@ -28,7 +33,7 @@ public class Entity
   /// <returns></returns>
   public string GetCanonicalId()
   {
-    return RoCrate.ResolveId(Identifier);
+    return RoCrate.ResolveId(Id);
   }
 
   /// <summary>
@@ -93,16 +98,16 @@ public class Entity
   {
     if (key.StartsWith('@')) throw new Exception($"Cannot append to {key}");
     if (value is null) throw new NullReferenceException("value cannot be null.");
-    
+
     var newItem = new Part { Identifier = value.GetCanonicalId() };
-    var itemList = new List<Part>{ newItem };
-    
+    var itemList = new List<Part> { newItem };
+
     if (Properties.TryGetPropertyValue(key, out var propsJson))
     {
       var currentItems = propsJson.Deserialize<List<Part>>() ?? new List<Part>();
       if (currentItems.Count > 0) itemList.InsertRange(0, currentItems);
     }
-    
+
     SetProperty(key, itemList);
   }
 
@@ -119,7 +124,7 @@ public class Entity
   {
     var emptyJsonString = new Dictionary<string, string>
     {
-      { "@id", Identifier },
+      { "@id", Id },
       { "@type", DefaultType }
     };
     var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();

--- a/lib/ROCrates.Net/Models/Entity.cs
+++ b/lib/ROCrates.Net/Models/Entity.cs
@@ -11,11 +11,7 @@ public class Entity
   private protected string DefaultType = "Thing";
   public ROCrate RoCrate { get; set; }
 
-  public string Id
-  {
-    get => GetProperty<string>("@id");
-    set => SetProperty("@id", value);
-  }
+  public string Id { get; set; }
 
   public JsonObject Properties { get; set; }
 

--- a/lib/ROCrates.Net/Models/File.cs
+++ b/lib/ROCrates.Net/Models/File.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace ROCrates.Models;
@@ -28,7 +27,7 @@ public class File : FileOrDir
   ///     If the file is on disk, it will be copied to a new location under "<c>basePath</c>".
   ///   </para>
   ///   <para>
-  ///     In either case, the file will be saved to "<c>basePath/Identifier</c>"
+  ///     In either case, the file will be saved to "<c>basePath/Id</c>"
   ///   </para>
   /// </summary>
   /// <example>
@@ -47,7 +46,7 @@ public class File : FileOrDir
   /// <param name="basePath">The path the file will be written to.</param>
   public override void Write(string basePath)
   {
-    var outFilePath = Path.Join(basePath, Identifier);
+    var outFilePath = Path.Join(basePath, Id);
     var outFileParent = Path.GetDirectoryName(outFilePath);
     if (outFileParent == null) return;
     if (Uri.IsWellFormedUriString(_source, UriKind.Absolute))

--- a/lib/ROCrates.Net/Models/FileOrDir.cs
+++ b/lib/ROCrates.Net/Models/FileOrDir.cs
@@ -8,6 +8,7 @@ public class FileOrDir : DataEntity
   protected string? _destPath;
   protected bool _fetchRemote;
   protected bool _validateUrl;
+
   public FileOrDir(ROCrate crate, string? identifier = null, JsonObject? properties = null, string? source = null,
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties)
   {
@@ -22,20 +23,21 @@ public class FileOrDir : DataEntity
       {
         throw new Exception("destPath must be a relative path, not an absolute path.");
       }
+
       // Convert Windows paths to POSIX
-      Identifier = _destPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+      Id = _destPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     }
     else if (Uri.IsWellFormedUriString(_source, UriKind.RelativeOrAbsolute) && _fetchRemote)
     {
-      Identifier = Path.GetFileNameWithoutExtension(_source);
+      Id = Path.GetFileNameWithoutExtension(_source);
     }
     else if (Path.GetFileName(_source) != String.Empty)
     {
-      Identifier = Path.GetFileNameWithoutExtension(_source);
+      Id = Path.GetFileNameWithoutExtension(_source);
     }
     else
     {
-      Identifier = _source;
+      Id = _source;
     }
   }
 }

--- a/lib/ROCrates.Net/Models/Metadata.cs
+++ b/lib/ROCrates.Net/Models/Metadata.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace ROCrates.Models;
@@ -21,9 +20,9 @@ public class Metadata : File
     DefaultType = "CreativeWork";
     Properties = _empty();
     if (properties is not null) _unpackProperties(properties);
-    SetProperty("conformsTo", new Dictionary<string, string>{{"@id", Profile}});
-    SetProperty("about", new Dictionary<string, string>{{"@id", "./"}});
-    Identifier = source ?? destPath ?? BaseName;
+    SetProperty("conformsTo", new Dictionary<string, string> { { "@id", Profile } });
+    SetProperty("about", new Dictionary<string, string> { { "@id", "./" } });
+    Id = source ?? destPath ?? BaseName;
   }
 
   private JsonObject _generate()
@@ -34,7 +33,7 @@ public class Metadata : File
 
   public override void Write(string basePath)
   {
-    var outPath = Path.Combine(basePath, Identifier);
+    var outPath = Path.Combine(basePath, Id);
     var metadataJson = _generate();
     System.IO.File.WriteAllText(outPath, metadataJson.ToString());
   }

--- a/lib/ROCrates.Net/Models/TestDefinition.cs
+++ b/lib/ROCrates.Net/Models/TestDefinition.cs
@@ -13,7 +13,7 @@ public class TestDefinition : File
     Properties = _empty();
     if (properties is not null) _unpackProperties(properties);
   }
-  
+
   public string? EngineVersion
   {
     get => GetProperty<string>("engineVersion");
@@ -30,7 +30,7 @@ public class TestDefinition : File
   {
     var emptyJsonString = new Dictionary<string, string>
     {
-      { "@id", Identifier },
+      { "@id", Id },
     };
     var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
     var typesList = new List<string> { "File", "TestDefinition" };

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -235,9 +235,9 @@ public class ROCrate
   {
     var testRefProp = "mentions";
     if (mainEntity is null && _mainEntity is null) testRefProp = "about";
-    
+
     var suite = new TestSuite(this, identifier);
-    suite.Name = name ?? suite.Identifier.TrimStart('#');
+    suite.Name = name ?? suite.Id.TrimStart('#');
 
     if (mainEntity is not null) suite.SetProperty("mainEntity", mainEntity);
     else if (_mainEntity is not null) suite.SetProperty("mainEntity", _mainEntity);
@@ -263,12 +263,13 @@ public class ROCrate
   /// <param name="testService">The service used to run the test instance.</param>
   /// <param name="name">The name of the test instance.</param>
   /// <returns>The <see cref="TestInstance"/> with the given parameters.</returns>
-  public TestInstance AddTestInstance(TestSuite testSuite, string url, string resource = "",  TestService? testService = null, string? name = null)
+  public TestInstance AddTestInstance(TestSuite testSuite, string url, string resource = "",
+    TestService? testService = null, string? name = null)
   {
     var testInstance = new TestInstance(this);
     testInstance.SetProperty("url", url);
     testInstance.SetProperty("resource", resource);
-    testInstance.Name = name ?? testInstance.Identifier.TrimStart('#');
+    testInstance.Name = name ?? testInstance.Id.TrimStart('#');
     if (testService is not null) testInstance.RunsOn = testService;
     testSuite.AppendTo("instance", testInstance);
     Metadata.ExtraTerms = JsonSerializer.SerializeToNode(new TestingExtraTerms()).AsObject();


### PR DESCRIPTION
## Overview

Rename `Identifier` prop to `Id` for all Entities. Add own `Identifier` prop to `ComputerLanguage` because it's meant to have one.

## Azure Boards

- AB#99645
- AB#99647
- AB#99766
