### PR TITLE
AB#101861: FileOrDir and subclass Id resolution is incorrect

### DIFF
--- a/lib/ROCrates.Net.Tests/TestFile.cs
+++ b/lib/ROCrates.Net.Tests/TestFile.cs
@@ -20,7 +20,7 @@ public class TestFile : IClassFixture<TestFileFixture>
     // Arrange
     var testDestPath = Path.Combine(_testBasePath, "ext", _testFileFixture.TestFileName);
     var fileEntity = new Models.File(
-      new ROCrate(_testFileFixture.TestFileName),
+      new ROCrate(),
       source: Path.Combine(_testBasePath, _testFileFixture.TestFileName),
       destPath: testDestPath);
 
@@ -36,7 +36,7 @@ public class TestFile : IClassFixture<TestFileFixture>
   {
     // Arrange
     var fileEntity = new Models.File(
-      new ROCrate(_testFileFixture.TestFileName),
+      new ROCrate(),
       source: Path.Combine(_testBasePath, _testFileFixture.TestFileName));
 
     // Act
@@ -53,7 +53,7 @@ public class TestFile : IClassFixture<TestFileFixture>
     var url = "https://hdruk.github.io/hutch/docs/devs";
     var fileName = url.Split('/').Last();
     var fileEntity = new Models.File(
-      new ROCrate(_testFileFixture.TestFileName),
+      new ROCrate(),
       source: url,
       validateUrl: true,
       fetchRemote: true);

--- a/lib/ROCrates.Net.Tests/TestFileOrDir.cs
+++ b/lib/ROCrates.Net.Tests/TestFileOrDir.cs
@@ -29,19 +29,23 @@ public class TestFileOrDir
   }
 
   [Fact]
-  public void Test_Identifier_Is_FileNameOnly()
+  public void Test_Identifier_Is_FileName_With_Extension()
   {
-    // relative source
-    var dataEntity = new FileOrDir(
+    // Arrange
+    var localName = "./path/to/my-file.txt";
+    var remaoteName = "ftp:///path/to/my-file.txt";
+
+    // Act
+    var dataEntityWithLocal = new FileOrDir(
       new ROCrate("my-test.zip"),
       source: "./path/to/my-file.txt");
-    Assert.Equal("my-file", dataEntity.Id);
-
-    // remote source
-    dataEntity = new FileOrDir(
+    var dataEntityWithRemote = new FileOrDir(
       new ROCrate("my-test.zip"),
       source: "ftp:///path/to/my-file.txt",
       fetchRemote: true);
-    Assert.Equal("my-file", dataEntity.Id);
+
+    // Assert
+    Assert.Equal("my-file.txt", dataEntityWithLocal.Id);
+    Assert.Equal("my-file.txt", dataEntityWithRemote.Id);
   }
 }

--- a/lib/ROCrates.Net.Tests/TestFileOrDir.cs
+++ b/lib/ROCrates.Net.Tests/TestFileOrDir.cs
@@ -32,8 +32,8 @@ public class TestFileOrDir
   public void Test_Identifier_Is_FileName_With_Extension()
   {
     // Arrange
-    var localName = "./path/to/my-file.txt";
-    var remaoteName = "ftp:///path/to/my-file.txt";
+    const string localName = "./path/to/my-file.txt";
+    const string remoteName = "ftp:///path/to/my-file.txt";
 
     // Act
     var dataEntityWithLocal = new FileOrDir(
@@ -41,7 +41,7 @@ public class TestFileOrDir
       source: localName);
     var dataEntityWithRemote = new FileOrDir(
       new ROCrate("my-test.zip"),
-      source: remaoteName,
+      source: remoteName,
       fetchRemote: true);
 
     // Assert

--- a/lib/ROCrates.Net.Tests/TestFileOrDir.cs
+++ b/lib/ROCrates.Net.Tests/TestFileOrDir.cs
@@ -38,14 +38,29 @@ public class TestFileOrDir
     // Act
     var dataEntityWithLocal = new FileOrDir(
       new ROCrate("my-test.zip"),
-      source: "./path/to/my-file.txt");
+      source: localName);
     var dataEntityWithRemote = new FileOrDir(
       new ROCrate("my-test.zip"),
-      source: "ftp:///path/to/my-file.txt",
+      source: remaoteName,
       fetchRemote: true);
 
     // Assert
     Assert.Equal("my-file.txt", dataEntityWithLocal.Id);
     Assert.Equal("my-file.txt", dataEntityWithRemote.Id);
+  }
+
+  [Fact]
+  public void Test_Identifier_Is_DirName()
+  {
+    // Arrange
+    var dirName = "./path/to/my-dir/";
+
+    // Act
+    var dataEntityWithDir = new FileOrDir(
+      new ROCrate("my-test.zip"),
+      source: dirName);
+
+    // Assert
+    Assert.Equal(dirName, dataEntityWithDir.Id);
   }
 }

--- a/lib/ROCrates.Net/Models/File.cs
+++ b/lib/ROCrates.Net/Models/File.cs
@@ -27,29 +27,26 @@ public class File : FileOrDir
   }
 
   /// <summary>
-  ///   <para>Write file contents to the specified path. e.g. The root path of an RO-Crate.</para>
-  ///   <para>
-  ///     If the file is a remote file, and <c>fetchUrl</c> is set to <c>true</c>, the file will be downloaded under
-  ///     "<c>basePath</c>".
-  ///   </para>
-  ///   <para>
-  ///     If the file is on disk, it will be copied to a new location under "<c>basePath</c>".
-  ///   </para>
-  ///   <para>
-  ///     In either case, the file will be saved to "<c>basePath/Id</c>"
-  ///   </para>
+  /// <para>Write file contents to the specified path. e.g. The root path of an RO-Crate.</para>
+  /// <para>
+  /// If the file is a remote file, and <c>fetchUrl</c> is set to <c>true</c>, the file will be downloaded under
+  /// "<c>basePath</c>".
+  /// </para>
+  /// <para>
+  /// If the file is on disk, it will be copied to a new location under "<c>basePath</c>".
+  /// </para>
+  /// <para>In either case, the file will be saved to "<c>basePath/Id</c>"</para>
   /// </summary>
   /// <example>
   /// <code>
   /// var url = "https://hdruk.github.io/hutch/docs/devs";
   /// var fileName = url.Split('/').Last();
   /// var fileEntity = new Models.File(
-  ///    new ROCrate("myCrate.zip"),
+  ///    new ROCrate(),
   ///    source: url,
   ///    validateUrl: true,
   ///    fetchRemote: true);
   /// fileEntity.Write("myCrate");
-  /// Assert.True(File.Exists(Path.Combine("myCrate", fileName)));
   /// </code>
   /// </example>
   /// <param name="basePath">The path the file will be written to.</param>

--- a/lib/ROCrates.Net/Models/File.cs
+++ b/lib/ROCrates.Net/Models/File.cs
@@ -80,7 +80,8 @@ public class File : FileOrDir
     else
     {
       Directory.CreateDirectory(outFileParent);
-      System.IO.File.Copy(_source, outFilePath, overwrite: true);
+      if (System.IO.File.Exists(outFilePath)) return;
+      System.IO.File.Copy(_source, outFilePath);
     }
   }
 

--- a/lib/ROCrates.Net/Models/FileOrDir.cs
+++ b/lib/ROCrates.Net/Models/FileOrDir.cs
@@ -33,11 +33,11 @@ public class FileOrDir : DataEntity
     }
     else if (Uri.IsWellFormedUriString(_source, UriKind.RelativeOrAbsolute) && _fetchRemote)
     {
-      Id = Path.GetFileNameWithoutExtension(_source);
+      Id = Path.GetFileName(_source);
     }
     else if (Path.GetFileName(_source) != String.Empty)
     {
-      Id = Path.GetFileNameWithoutExtension(_source);
+      Id = Path.GetFileName(_source);
     }
     else
     {


### PR DESCRIPTION
## Overview

File entities were not saving with their extensions in the `@id` tags. This fix corrects that.

## Azure Boards

- AB#101862
- AB#101863

## Notes

A unit test relating to saving files to the same place was discovered in while investigating this bug. A fix for that is also in this PR.
