### PR TITLE
AB#102471: Recreate agent as ASP.NET Core project

### DIFF
--- a/Hutch.sln
+++ b/Hutch.sln
@@ -5,12 +5,13 @@ VisualStudioVersion = 17.0.32002.185
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HutchManager", "app\HutchManager\HutchManager.csproj", "{E159D135-B386-4C24-9EB4-0A2116681EFD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HutchAgent", "app\HutchAgent\HutchAgent.csproj", "{94DC3895-F331-4AFB-BCBA-8038209E0834}"
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lib", "lib", "{56701705-F669-4223-988E-D8CC2B308805}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ROCrates.Net", "lib\ROCrates.Net\ROCrates.Net.csproj", "{F676DC41-E9BA-4E28-BB08-E985656046FA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ROCrates.Net.Tests", "lib\ROCrates.Net.Tests\ROCrates.Net.Tests.csproj", "{B288D13A-8F45-485D-A9D0-F66A2BEADC9C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HutchAgent", "app\HutchAgent\HutchAgent.csproj", "{2D9B3839-B34E-4897-ADF2-96F47A3C401F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,10 +23,6 @@ Global
 		{E159D135-B386-4C24-9EB4-0A2116681EFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E159D135-B386-4C24-9EB4-0A2116681EFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E159D135-B386-4C24-9EB4-0A2116681EFD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{94DC3895-F331-4AFB-BCBA-8038209E0834}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{94DC3895-F331-4AFB-BCBA-8038209E0834}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{94DC3895-F331-4AFB-BCBA-8038209E0834}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{94DC3895-F331-4AFB-BCBA-8038209E0834}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F676DC41-E9BA-4E28-BB08-E985656046FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F676DC41-E9BA-4E28-BB08-E985656046FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F676DC41-E9BA-4E28-BB08-E985656046FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -34,6 +31,10 @@ Global
 		{B288D13A-8F45-485D-A9D0-F66A2BEADC9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B288D13A-8F45-485D-A9D0-F66A2BEADC9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B288D13A-8F45-485D-A9D0-F66A2BEADC9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D9B3839-B34E-4897-ADF2-96F47A3C401F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D9B3839-B34E-4897-ADF2-96F47A3C401F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D9B3839-B34E-4897-ADF2-96F47A3C401F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D9B3839-B34E-4897-ADF2-96F47A3C401F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/app/HutchAgent/HutchAgent.csproj
+++ b/app/HutchAgent/HutchAgent.csproj
@@ -1,15 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <UserSecretsId>d12382f7-affd-42bf-96ca-0958b28e7215</UserSecretsId>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
 
 </Project>

--- a/app/HutchAgent/Program.cs
+++ b/app/HutchAgent/Program.cs
@@ -1,21 +1,6 @@
-﻿using HutchAgent.Models;
-using HutchAgent.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
 
-namespace HutchAgent;
+app.MapGet("/", () => "Hello World!");
 
-public class Program
-{
-  public static void Main(string[] args)
-  {
-    IHost host = Host.CreateDefaultBuilder(args)
-      .ConfigureServices((hostContext, services) =>
-      {
-        services.AddHostedService<WorkflowTriggerService>();
-        services.AddOptions<WorkflowTriggerOptions>().Bind(hostContext.Configuration.GetSection("Wfexs"));
-      })
-      .Build();
-    host.Run();
-  }
-}
+app.Run();

--- a/app/HutchAgent/Properties/launchSettings.json
+++ b/app/HutchAgent/Properties/launchSettings.json
@@ -1,9 +1,27 @@
-{
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:46941",
+      "sslPort": 44327
+    }
+  },
   "profiles": {
     "HutchAgent": {
       "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7239;http://localhost:5209",
       "environmentVariables": {
-        "DOTNET_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/app/HutchAgent/appsettings.Development.json
+++ b/app/HutchAgent/appsettings.Development.json
@@ -4,6 +4,5 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  },
-  "AllowedHosts": "*"
+  }
 }


### PR DESCRIPTION
## Overview

Delete HutchAgent proj and remake as a basic ASP.NET Core API app, add back Service and Model from previous version

## Azure Boards

- AB#102474
- AB#102473
- AB#102472
- AB#102475

