### PR TITLE
AB#94504: Merge WfExS output crate into parent crate

### DIFF
--- a/app/HutchAgent.Tests/TestCrateMergeService.cs
+++ b/app/HutchAgent.Tests/TestCrateMergeService.cs
@@ -1,0 +1,57 @@
+using HutchAgent.Services;
+
+namespace HutchAgent.Tests;
+
+public class TestCrateMergeService
+{
+  [Fact]
+  public void MergeCrates_Copies_ZipToDestination()
+  {
+    // Arrange
+    var destinationDir = new DirectoryInfo("save/here/");
+    var zipFile = new FileInfo("test-zip.zip");
+    File.Create(zipFile.Name).Close();
+    Directory.CreateDirectory(destinationDir.ToString());
+
+    var service = new CrateMergerService();
+
+    // Act
+    service.MergeCrates(zipFile.Name, destinationDir.ToString());
+
+    // Assert
+    Assert.True(File.Exists(Path.Combine(destinationDir.ToString(), zipFile.Name)));
+
+    // Clean up
+    if (zipFile.Exists) zipFile.Delete();
+    if (destinationDir.Exists) destinationDir.Parent!.Delete(true);
+  }
+
+  [Fact]
+  public void MergeCrates_Zips_DestinationToParent()
+  {
+    // Arrange
+
+    // Act
+
+    // Assert
+  }
+
+  [Fact]
+  public void MergeCrates_Throws_WhenDestinationNonExistent()
+  {
+    // Arrange
+    var zipFileName = "my-file.zip";
+    var destinationDir = "non/existent/dir/";
+    Directory.CreateDirectory("non/existent/");
+    var service = new CrateMergerService();
+
+    // Act
+    var action = () => service.MergeCrates(zipFileName, destinationDir);
+
+    // Assert
+    Assert.Throws<DirectoryNotFoundException>(action);
+
+    // Clean up
+    if (Directory.Exists("non/")) Directory.Delete("non/", true);
+  }
+}

--- a/app/HutchAgent.Tests/TestCrateMergeService.cs
+++ b/app/HutchAgent.Tests/TestCrateMergeService.cs
@@ -10,6 +10,7 @@ public class TestCrateMergeService
     // Arrange
     var destinationDir = new DirectoryInfo("save/here/");
     var zipFile = new FileInfo("test-zip.zip");
+    var expectedFile = new FileInfo(Path.Combine(destinationDir.ToString(), zipFile.Name));
     File.Create(zipFile.Name).Close();
     Directory.CreateDirectory(destinationDir.ToString());
 
@@ -19,7 +20,7 @@ public class TestCrateMergeService
     service.MergeCrates(zipFile.Name, destinationDir.ToString());
 
     // Assert
-    Assert.True(File.Exists(Path.Combine(destinationDir.ToString(), zipFile.Name)));
+    Assert.True(expectedFile.Exists);
 
     // Clean up
     if (zipFile.Exists) zipFile.Delete();
@@ -27,13 +28,27 @@ public class TestCrateMergeService
   }
 
   [Fact]
-  public void MergeCrates_Zips_DestinationToParent()
+  public void ZipCrate_Zips_DestinationToParent()
   {
     // Arrange
+    var destinationDir = new DirectoryInfo("save2/here/");
+    var zipFile = new FileInfo(Path.Combine(destinationDir.ToString(), "test-zip.zip"));
+    var expectedFile = new FileInfo($"save2/{destinationDir.Name}-merged.zip");
+
+    Directory.CreateDirectory(destinationDir.ToString());
+    File.Create(zipFile.Name).Close();
+
+    var service = new CrateMergerService();
 
     // Act
+    service.ZipCrate(destinationDir.ToString());
 
     // Assert
+    Assert.True(expectedFile.Exists);
+
+    // Clean up
+    if (zipFile.Exists) zipFile.Delete();
+    if (destinationDir.Exists) destinationDir.Parent!.Delete(true);
   }
 
   [Fact]
@@ -53,5 +68,19 @@ public class TestCrateMergeService
 
     // Clean up
     if (Directory.Exists("non/")) Directory.Delete("non/", true);
+  }
+
+  [Fact]
+  public void ZipCrate_Throws_WhenDestinationNonExistent()
+  {
+    // Arrange
+    var destinationDir = "non/existent/dir/";
+    var service = new CrateMergerService();
+
+    // Act
+    var action = () => service.ZipCrate(destinationDir);
+
+    // Assert
+    Assert.Throws<DirectoryNotFoundException>(action);
   }
 }

--- a/app/HutchAgent/Program.cs
+++ b/app/HutchAgent/Program.cs
@@ -25,6 +25,7 @@ builder.Services
   .AddScoped<WorkflowTriggerService>()
   .AddTransient<MinioService>()
   .AddTransient<WfexsJobService>()
+  .AddTransient<CrateMergerService>()
   .AddHostedService<WatchFolderService>();
 
 #endregion

--- a/app/HutchAgent/Services/CrateMergerService.cs
+++ b/app/HutchAgent/Services/CrateMergerService.cs
@@ -46,16 +46,22 @@ public class CrateMergerService
   }
 
   /// <summary>
-  /// Update the metadata of a 
+  /// Update the target metadata file in an RO-Crate.
   /// </summary>
-  /// <param name="pathToMetadata"></param>
-  /// <param name="fileToAdd"></param>
-  /// <exception cref="FileNotFoundException"></exception>
-  /// <exception cref="InvalidDataException"></exception>
+  /// <param name="pathToMetadata">The path to the metadata file that needs updating.</param>
+  /// <param name="fileToAdd">The path of the file to add to the metadata.</param>
+  /// <exception cref="FileNotFoundException">
+  /// Metadata file and/or file to be added to the metadata could not be found.
+  /// </exception>
+  /// <exception cref="InvalidDataException">The metadata file is invalid.</exception>
   public void UpdateMetadata(string pathToMetadata, string fileToAdd)
   {
     if (!File.Exists(pathToMetadata))
       throw new FileNotFoundException("Could not locate the metadata for the RO-Crate.");
+
+    if (!File.Exists(fileToAdd))
+      throw new FileNotFoundException("Could not locate the file to add to the metadata.");
+
     var metadataJson = File.ReadAllText(pathToMetadata);
     var metadata = JsonNode.Parse(metadataJson);
     if (metadata is null) throw new InvalidDataException($"{pathToMetadata} is not a valid JSON file.");
@@ -64,7 +70,6 @@ public class CrateMergerService
       throw new InvalidDataException("Cannot find entities in the RO-Crate metadata.");
 
     var rootDatasetProperties = graph.AsArray().First(g => g["@id"].ToString() == "./");
-    var rootDatasetPath = rootDatasetProperties.GetPath();
     var file = new ROCrates.Models.File(source: fileToAdd).Serialize();
     rootDatasetProperties["hasPart"].AsArray().Add(JsonNode.Parse(file));
 

--- a/app/HutchAgent/Services/CrateMergerService.cs
+++ b/app/HutchAgent/Services/CrateMergerService.cs
@@ -70,7 +70,7 @@ public class CrateMergerService
       throw new InvalidDataException("Cannot find entities in the RO-Crate metadata.");
 
     var rootDatasetProperties = graph.AsArray().First(g => g["@id"].ToString() == "./");
-    var file = new ROCrates.Models.File(source: fileToAdd).Serialize();
+    var file = new ROCrates.Models.File(source: Path.GetFileName(fileToAdd)).Serialize();
     rootDatasetProperties["hasPart"].AsArray().Add(JsonNode.Parse(file));
 
     File.WriteAllText(pathToMetadata, metadata.ToString());

--- a/app/HutchAgent/Services/CrateMergerService.cs
+++ b/app/HutchAgent/Services/CrateMergerService.cs
@@ -1,0 +1,39 @@
+namespace HutchAgent.Services;
+
+/// <summary>
+/// This service merges an output RO-Crate back into its input RO-Crate.
+/// </summary>
+public class CrateMergerService
+{
+  /// <summary>
+  /// Copy a source zipped RO-Crate into an unzipped destination RO-Crate and zip the
+  /// destination RO-Crate.
+  /// </summary>
+  /// <param name="sourceZip"></param>
+  /// <param name="mergeInto"></param>
+  /// <exception cref="DirectoryNotFoundException">
+  /// The directory you are attempting to merge doesn't exists.
+  /// The parent of the destination directory couldn't be found or does not exists.
+  /// </exception>
+  public void MergeCrates(string sourceZip, string mergeInto)
+  {
+    // Get information on destination and make sure it exists
+    var destinationInfo = new DirectoryInfo(mergeInto);
+    if (!destinationInfo.Exists) throw new DirectoryNotFoundException($"{mergeInto} does not exist.");
+
+    // Get the parent directory of the merge destination
+    var parentInfo = destinationInfo.Parent;
+    if (parentInfo is null) throw new DirectoryNotFoundException($"Cannot get parent of {mergeInto}.");
+    var parent = parentInfo!.ToString();
+
+    // Copy the result RO-Crate (`file`) into the unzipped original RO-Crate
+    File.Copy(sourceZip, Path.Combine(mergeInto, Path.GetFileName(sourceZip)));
+
+    // Todo: Alter the input RO-Crate ro-crate-metadata.json
+
+    // Zip the original crate, now containing the zipped result crate, and upload to S3.
+    // var fileNoExt = destinationInfo.Name;
+    // var zipFile = $"{fileNoExt}-merged.zip";
+    // ZipFile.CreateFromDirectory(mergeInto, Path.Combine(parent, zipFile));
+  }
+}

--- a/app/HutchAgent/Services/CrateMergerService.cs
+++ b/app/HutchAgent/Services/CrateMergerService.cs
@@ -1,3 +1,5 @@
+using System.IO.Compression;
+
 namespace HutchAgent.Services;
 
 /// <summary>
@@ -21,19 +23,26 @@ public class CrateMergerService
     var destinationInfo = new DirectoryInfo(mergeInto);
     if (!destinationInfo.Exists) throw new DirectoryNotFoundException($"{mergeInto} does not exist.");
 
-    // Get the parent directory of the merge destination
-    var parentInfo = destinationInfo.Parent;
-    if (parentInfo is null) throw new DirectoryNotFoundException($"Cannot get parent of {mergeInto}.");
-    var parent = parentInfo!.ToString();
-
     // Copy the result RO-Crate (`file`) into the unzipped original RO-Crate
     File.Copy(sourceZip, Path.Combine(mergeInto, Path.GetFileName(sourceZip)));
 
     // Todo: Alter the input RO-Crate ro-crate-metadata.json
+  }
 
-    // Zip the original crate, now containing the zipped result crate, and upload to S3.
-    // var fileNoExt = destinationInfo.Name;
-    // var zipFile = $"{fileNoExt}-merged.zip";
-    // ZipFile.CreateFromDirectory(mergeInto, Path.Combine(parent, zipFile));
+  /// <summary>
+  /// Zip a directory containing the contents of an RO-Crate, saving it in the directory's parent directory
+  /// with a name like "cratePath-merged.zip".
+  /// </summary>
+  /// <param name="cratePath">The path to the unzipped RO-Crate.</param>
+  /// <exception cref="DirectoryNotFoundException">
+  /// Thrown when the directory of the RO-Crate does not exists.
+  /// </exception>
+  public void ZipCrate(string cratePath)
+  {
+    var dirInfo = new DirectoryInfo(cratePath);
+    if (!dirInfo.Exists) throw new DirectoryNotFoundException($"{cratePath} does not exists.");
+    var parent = dirInfo.Parent;
+    var zipFile = $"{dirInfo.Name}-merged.zip";
+    ZipFile.CreateFromDirectory(cratePath, Path.Combine(parent!.ToString(), zipFile));
   }
 }

--- a/app/HutchAgent/Services/MinioService.cs
+++ b/app/HutchAgent/Services/MinioService.cs
@@ -11,7 +11,7 @@ public class MinioService
   private readonly ILogger<MinioService> _logger;
   private readonly MinioOptions _options;
 
-  public MinioService(IOptions<MinioOptions> minioOptions, ILogger<MinioService> logger, IOptions<MinioOptions> options)
+  public MinioService(ILogger<MinioService> logger, IOptions<MinioOptions> options)
   {
     _logger = logger;
     _options = options.Value;

--- a/app/HutchAgent/Services/WatchFolderService.cs
+++ b/app/HutchAgent/Services/WatchFolderService.cs
@@ -8,18 +8,16 @@ public class WatchFolderService : BackgroundService
 {
   private readonly WatchFolderOptions _options;
   private readonly ILogger<WatchFolderService> _logger;
-  private readonly MinioService _minioService;
-  private readonly WfexsJobService _wfexsJobService;
-  private readonly CrateMergerService _crateMergerService;
+  private MinioService? _minioService;
+  private WfexsJobService? _wfexsJobService;
+  private CrateMergerService? _crateMergerService;
   private readonly IServiceProvider _serviceProvider;
 
-  public WatchFolderService(IOptions<WatchFolderOptions> options, ILogger<WatchFolderService> logger, IServiceProvider serviceProvider)
+  public WatchFolderService(IOptions<WatchFolderOptions> options, ILogger<WatchFolderService> logger,
+    IServiceProvider serviceProvider)
   {
     _options = options.Value;
     _logger = logger;
-    _minioService = serviceProvider.GetService<MinioService>() ?? throw new InvalidOperationException();
-    _wfexsJobService = serviceProvider.GetService<WfexsJobService>() ?? throw new InvalidOperationException();
-    _crateMergerService = serviceProvider.GetService<CrateMergerService>() ?? throw new InvalidOperationException();
     _serviceProvider = serviceProvider;
   }
 
@@ -33,9 +31,12 @@ public class WatchFolderService : BackgroundService
 
     while (!stoppingToken.IsCancellationRequested)
     {
-      using (var scope = _serviceProvider.CreateScope()) {
+      using (var scope = _serviceProvider.CreateScope())
+      {
         _minioService = scope.ServiceProvider.GetService<MinioService>() ?? throw new InvalidOperationException();
         _wfexsJobService = scope.ServiceProvider.GetService<WfexsJobService>() ?? throw new InvalidOperationException();
+        _crateMergerService = scope.ServiceProvider.GetService<CrateMergerService>() ??
+                              throw new InvalidOperationException();
         _watchFolder();
         MergeResults();
       }

--- a/app/HutchAgent/Services/WfexsJobService.cs
+++ b/app/HutchAgent/Services/WfexsJobService.cs
@@ -54,6 +54,11 @@ public class WfexsJobService
     return list;
   }
 
+  public async Task<List<WfexsJob>> ListFinishedJobs()
+  {
+    return await _db.WfexsJobs.AsNoTracking().Where(x => x.RunFinished).ToListAsync();
+  }
+
   /// <summary>
   /// Get a <see cref="WfexsJob"/> with the given ID from the database.
   /// </summary>


### PR DESCRIPTION
## Overview

Result RO-Crates can be merged into the input RO-Crate. The metadata of the input RO-Crate is modified to include the the zipped result crate. The merged file is save to S3.

## Azure Boards

- AB#104220
- AB#104222
- AB#104221
- AB#104225
