### PR TITLE
AB#107048: WatchFolder should check a job is finished first

### DIFF
--- a/app/HutchAgent/HostedServices/WatchFolderHostedService.cs
+++ b/app/HutchAgent/HostedServices/WatchFolderHostedService.cs
@@ -1,19 +1,20 @@
 using HutchAgent.Config;
+using HutchAgent.Services;
 using Microsoft.Extensions.Options;
 using Minio.Exceptions;
 
-namespace HutchAgent.Services;
+namespace HutchAgent.HostedServices;
 
-public class WatchFolderService : BackgroundService
+public class WatchFolderHostedService : BackgroundService
 {
   private readonly WatchFolderOptions _options;
-  private readonly ILogger<WatchFolderService> _logger;
+  private readonly ILogger<WatchFolderHostedService> _logger;
   private IResultsStoreWriter? _resultsStoreWriter;
   private WfexsJobService? _wfexsJobService;
   private CrateMergerService? _crateMergerService;
   private readonly IServiceProvider _serviceProvider;
 
-  public WatchFolderService(IOptions<WatchFolderOptions> options, ILogger<WatchFolderService> logger,
+  public WatchFolderHostedService(IOptions<WatchFolderOptions> options, ILogger<WatchFolderHostedService> logger,
     IServiceProvider serviceProvider)
   {
     _options = options.Value;

--- a/app/HutchAgent/Program.cs
+++ b/app/HutchAgent/Program.cs
@@ -1,6 +1,7 @@
 using HutchAgent.Config;
 using HutchAgent.Data;
 using HutchAgent.Extensions;
+using HutchAgent.HostedServices;
 using HutchAgent.Services;
 using Microsoft.EntityFrameworkCore;
 
@@ -27,7 +28,7 @@ builder.Services
   .AddResultsStore(builder.Configuration)
   .AddTransient<WfexsJobService>()
   .AddTransient<CrateMergerService>()
-  .AddHostedService<WatchFolderService>();
+  .AddHostedService<WatchFolderHostedService>();
 
 #endregion
 


### PR DESCRIPTION
## Overview

Check if a job is finished before attempting to upload to the results store.

## Azure Boards

- AB#107264
- AB#107265
