### PR TITLE
AB#107058: WfExS trigger threading etc.

### DIFF
--- a/app/HutchAgent/Config/JobPollingOptions.cs
+++ b/app/HutchAgent/Config/JobPollingOptions.cs
@@ -1,7 +1,6 @@
 namespace HutchAgent.Config;
 
-public class WatchFolderOptions
+public class JobPollingOptions
 {
-  public string Path { get; set; } = string.Empty;
   public int PollingIntervalSeconds { get; set; } = 5;
 }

--- a/app/HutchAgent/Data/Entities/WfexsJob.cs
+++ b/app/HutchAgent/Data/Entities/WfexsJob.cs
@@ -10,4 +10,6 @@ public class WfexsJob
   public string UnpackedPath { get; set; } = string.Empty;
   public string WfexsRunId { get; set; } = string.Empty;
   public bool RunFinished { get; set; }
+
+  public int Pid { get; set; }
 }

--- a/app/HutchAgent/Data/Entities/WfexsJob.cs
+++ b/app/HutchAgent/Data/Entities/WfexsJob.cs
@@ -10,6 +10,5 @@ public class WfexsJob
   public string UnpackedPath { get; set; } = string.Empty;
   public string WfexsRunId { get; set; } = string.Empty;
   public bool RunFinished { get; set; }
-
   public int Pid { get; set; }
 }

--- a/app/HutchAgent/HostedServices/JobPollingHostedService.cs
+++ b/app/HutchAgent/HostedServices/JobPollingHostedService.cs
@@ -6,18 +6,18 @@ using Minio.Exceptions;
 
 namespace HutchAgent.HostedServices;
 
-public class WatchFolderHostedService : BackgroundService
+public class JobPollingHostedService : BackgroundService
 {
   private readonly JobPollingOptions _options;
   private readonly WorkflowTriggerOptions _workflowTriggerOptions;
-  private readonly ILogger<WatchFolderHostedService> _logger;
+  private readonly ILogger<JobPollingHostedService> _logger;
   private IResultsStoreWriter? _resultsStoreWriter;
   private WfexsJobService? _wfexsJobService;
   private CrateMergerService? _crateMergerService;
   private readonly IServiceProvider _serviceProvider;
 
-  public WatchFolderHostedService(IOptions<JobPollingOptions> options,
-    IOptions<WorkflowTriggerOptions> workflowTriggerOptions, ILogger<WatchFolderHostedService> logger,
+  public JobPollingHostedService(IOptions<JobPollingOptions> options,
+    IOptions<WorkflowTriggerOptions> workflowTriggerOptions, ILogger<JobPollingHostedService> logger,
     IServiceProvider serviceProvider)
   {
     _options = options.Value;

--- a/app/HutchAgent/HostedServices/WatchFolderHostedService.cs
+++ b/app/HutchAgent/HostedServices/WatchFolderHostedService.cs
@@ -138,7 +138,7 @@ public class WatchFolderHostedService : BackgroundService
       catch (ArgumentException)
       {
         job.RunFinished = true;
-        _wfexsJobService.Set(job);
+        await _wfexsJobService.Set(job);
       }
     }
   }

--- a/app/HutchAgent/HostedServices/WatchFolderHostedService.cs
+++ b/app/HutchAgent/HostedServices/WatchFolderHostedService.cs
@@ -41,8 +41,8 @@ public class WatchFolderHostedService : BackgroundService
         _crateMergerService = scope.ServiceProvider.GetService<CrateMergerService>() ??
                               throw new InvalidOperationException();
         await CheckJobsFinished();
-        WatchFolder();
-        MergeResults();
+        await WatchFolder();
+        await MergeResults();
       }
 
       await Task.Delay(TimeSpan.FromSeconds(_options.PollingIntervalSeconds), stoppingToken);
@@ -60,7 +60,7 @@ public class WatchFolderHostedService : BackgroundService
     await base.StopAsync(stoppingToken);
   }
 
-  private async void WatchFolder()
+  private async Task WatchFolder()
   {
     var finishedJobs = await _wfexsJobService.ListFinishedJobs();
     foreach (var job in finishedJobs)
@@ -90,7 +90,7 @@ public class WatchFolderHostedService : BackgroundService
     }
   }
 
-  private async void MergeResults()
+  private async Task MergeResults()
   {
     var finishedJobs = await _wfexsJobService.ListFinishedJobs();
     foreach (var job in finishedJobs)

--- a/app/HutchAgent/HostedServices/WatchFolderHostedService.cs
+++ b/app/HutchAgent/HostedServices/WatchFolderHostedService.cs
@@ -44,7 +44,7 @@ public class WatchFolderHostedService : BackgroundService
         _crateMergerService = scope.ServiceProvider.GetService<CrateMergerService>() ??
                               throw new InvalidOperationException();
         await CheckJobsFinished();
-        await WatchFolder();
+        await UploadResults();
         await MergeResults();
       }
 
@@ -63,12 +63,17 @@ public class WatchFolderHostedService : BackgroundService
     await base.StopAsync(stoppingToken);
   }
 
-  private async Task WatchFolder()
+  private async Task UploadResults()
   {
     var finishedJobs = await _wfexsJobService.ListFinishedJobs();
     foreach (var job in finishedJobs)
     {
-      var pathToUpload = Path.Combine(_options.Path, $"{job.WfexsRunId}.zip");
+      var pathToUpload = Path.Combine(
+        _workflowTriggerOptions.ExecutorPath,
+        "wfexs-backend-test_WorkDir",
+        job.WfexsRunId,
+        "outputs",
+        "execution.crate.zip");
 
       if (await _resultsStoreWriter.ResultExists(Path.GetFileName(pathToUpload)))
       {

--- a/app/HutchAgent/HostedServices/WatchFolderHostedService.cs
+++ b/app/HutchAgent/HostedServices/WatchFolderHostedService.cs
@@ -8,19 +8,22 @@ namespace HutchAgent.HostedServices;
 
 public class WatchFolderHostedService : BackgroundService
 {
-  private readonly WatchFolderOptions _options;
+  private readonly JobPollingOptions _options;
+  private readonly WorkflowTriggerOptions _workflowTriggerOptions;
   private readonly ILogger<WatchFolderHostedService> _logger;
   private IResultsStoreWriter? _resultsStoreWriter;
   private WfexsJobService? _wfexsJobService;
   private CrateMergerService? _crateMergerService;
   private readonly IServiceProvider _serviceProvider;
 
-  public WatchFolderHostedService(IOptions<WatchFolderOptions> options, ILogger<WatchFolderHostedService> logger,
+  public WatchFolderHostedService(IOptions<JobPollingOptions> options,
+    IOptions<WorkflowTriggerOptions> workflowTriggerOptions, ILogger<WatchFolderHostedService> logger,
     IServiceProvider serviceProvider)
   {
     _options = options.Value;
     _logger = logger;
     _serviceProvider = serviceProvider;
+    _workflowTriggerOptions = workflowTriggerOptions.Value;
   }
 
   /// <summary>
@@ -29,7 +32,7 @@ public class WatchFolderHostedService : BackgroundService
   /// <param name="stoppingToken"></param>
   protected override async Task ExecuteAsync(CancellationToken stoppingToken)
   {
-    _logger.LogInformation($"Starting to watch folder {_options.Path}");
+    _logger.LogInformation("Polling WfExS Jobs.");
 
     while (!stoppingToken.IsCancellationRequested)
     {
@@ -55,7 +58,7 @@ public class WatchFolderHostedService : BackgroundService
   /// <param name="stoppingToken"></param>
   public override async Task StopAsync(CancellationToken stoppingToken)
   {
-    _logger.LogInformation($"Stopping watching folder {_options.Path}");
+    _logger.LogInformation("Stopping polling WfExS jobs.");
 
     await base.StopAsync(stoppingToken);
   }

--- a/app/HutchAgent/Migrations/20230530141658_AddWfexsJobPid.Designer.cs
+++ b/app/HutchAgent/Migrations/20230530141658_AddWfexsJobPid.Designer.cs
@@ -2,6 +2,7 @@
 using HutchAgent.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -9,9 +10,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace HutchAgent.Migrations
 {
     [DbContext(typeof(HutchAgentContext))]
-    partial class HutchAgentContextModelSnapshot : ModelSnapshot
+    [Migration("20230530141658_AddWfexsJobPid")]
+    partial class AddWfexsJobPid
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.5");

--- a/app/HutchAgent/Migrations/20230530141658_AddWfexsJobPid.cs
+++ b/app/HutchAgent/Migrations/20230530141658_AddWfexsJobPid.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HutchAgent.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWfexsJobPid : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Pid",
+                table: "WfexsJobs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Pid",
+                table: "WfexsJobs");
+        }
+    }
+}

--- a/app/HutchAgent/Program.cs
+++ b/app/HutchAgent/Program.cs
@@ -22,7 +22,7 @@ builder.Services.AddDbContext<HutchAgentContext>(o =>
 // All other services
 builder.Services
   .Configure<MinioOptions>(builder.Configuration.GetSection("MinIO"))
-  .Configure<WatchFolderOptions>(builder.Configuration.GetSection("WatchFolder"))
+  .Configure<JobPollingOptions>(builder.Configuration.GetSection("WatchFolder"))
   .Configure<WorkflowTriggerOptions>(builder.Configuration.GetSection("Wfexs"))
   .AddScoped<WorkflowTriggerService>()
   .AddResultsStore(builder.Configuration)

--- a/app/HutchAgent/Program.cs
+++ b/app/HutchAgent/Program.cs
@@ -28,7 +28,7 @@ builder.Services
   .AddResultsStore(builder.Configuration)
   .AddTransient<WfexsJobService>()
   .AddTransient<CrateMergerService>()
-  .AddHostedService<WatchFolderHostedService>();
+  .AddHostedService<JobPollingHostedService>();
 
 #endregion
 

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -165,6 +165,9 @@ public class WorkflowTriggerService
     if (process == null)
       throw new Exception("Could not start process");
 
+    // Get process PID
+    wfexsJob.Pid = process.Id;
+
     await using var streamWriter = process.StandardInput;
     if (streamWriter.BaseStream.CanWrite)
     {

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -195,25 +195,6 @@ public class WorkflowTriggerService
     // end the process
     process.Close();
 
-    // create the output RO-Crate
-    if (_wfexsRunId is null)
-    {
-      _logger.LogError("Unable to get Run ID; cannot create output RO-Crate.");
-      return;
-    }
-
-    try
-    {
-      await _createProvCrate(_wfexsRunId);
-      wfexsJob.RunFinished = true;
-    }
-    catch (Exception)
-    {
-      _logger.LogError($"Could not create the results RO-Crate for run {_wfexsRunId}");
-      // Make sure the job is marked as unfinished.
-      wfexsJob.RunFinished = false;
-    }
-
     // Update the job in the queue.
     await _wfexsJobService.Set(wfexsJob);
   }

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -179,18 +179,17 @@ public class WorkflowTriggerService
       streamWriter.Close();
     }
 
-    StreamReader reader = process.StandardOutput;
-    String? _wfexsRunId = null;
-    while (!process.HasExited)
+    // Read the stdout of the WfExS run to get the run ID
+    var reader = process.StandardOutput;
+    string? _wfexsRunId = null;
+    while (!process.HasExited && _wfexsRunId is null)
     {
       var stdOutLine = await reader.ReadLineAsync();
       if (stdOutLine is null) continue;
       var runName = _findRunName(stdOutLine);
-      if (runName is not null)
-      {
-        _wfexsRunId = runName;
-        wfexsJob.WfexsRunId = runName;
-      }
+      if (runName is null) continue;
+      _wfexsRunId = runName;
+      wfexsJob.WfexsRunId = runName;
     }
 
     // end the process

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -14,7 +14,7 @@ namespace HutchAgent.Services;
 public class WorkflowTriggerService
 {
   private readonly WorkflowTriggerOptions _workflowOptions;
-  private readonly WatchFolderOptions _watchFolderOptions;
+  private readonly JobPollingOptions _jobPollingOptions;
   private readonly ILogger<WorkflowTriggerService> _logger;
   private readonly string _activateVenv;
   private const string _bashCmd = "bash";
@@ -22,11 +22,11 @@ public class WorkflowTriggerService
   private readonly WfexsJobService _wfexsJobService;
 
   public WorkflowTriggerService(IOptions<WorkflowTriggerOptions> workflowOptions,
-    ILogger<WorkflowTriggerService> logger, IOptions<WatchFolderOptions> watchFolderOptions,
+    ILogger<WorkflowTriggerService> logger, IOptions<JobPollingOptions> watchFolderOptions,
     IServiceProvider serviceProvider)
   {
     _logger = logger;
-    _watchFolderOptions = watchFolderOptions.Value;
+    _jobPollingOptions = watchFolderOptions.Value;
     _workflowOptions = workflowOptions.Value;
     _activateVenv = "source " + _workflowOptions.VirtualEnvironmentPath;
     _wfexsJobService = serviceProvider.GetService<WfexsJobService>() ?? throw new InvalidOperationException();


### PR DESCRIPTION
## Overview

- Remove provenance crate creation
- Stop looking for WfExS Run name after it's found
- Convert Watch Folder service to Job Polling service that detects finished jobs by PID
- Uploading and merging of results looks for execution crate
- Upon job execution and determination of the run name, the agent detaches from the process to start another job

## Azure Boards

- AB#108609
- AB#108610
- AB#108611
- AB#108612
- AB#108615
- AB#108782
- AB#108616

## Notes

The execution crate is renamed from `execution.crate.zip` to `{run ID}.zip` so it unique when uploaded to results store.
