### PR TITLE
AB#108952: Use Reverse Proxy for Workflows (e.g. WorkflowHub) -> Nexus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,13 +40,26 @@ services:
       - $HOME/minio-data:$HOME/minio-data
     command: minio server $HOME/minio-data --console-address ":9001"
 
-  nginx:
-    image: nginx
+  # nginx:
+  #   image: nginx
+  #   restart: always
+  #   ports:
+  #     - "80:80" # HTTP
+  #     - "443:443" # HTTPS
+  #   volumes:
+  #     - $HOME/nginx.conf:/etc/nginx/nginx.conf:ro
+  #     - $HOME/cert.pem:/etc/nginx/cert.pem:ro
+  #     - $HOME/key.pem:/etc/nginx/key.pem:ro
+
+  docker-proxy:
+    image: tiangolo/docker-registry-proxy
     restart: always
     ports:
-      - "80:80" # HTTP
-      - "443:443" # HTTPS
+      - "3128:3128"
     volumes:
-      - $HOME/nginx.conf:/etc/nginx/nginx.conf:ro
-      - $HOME/cert.pem:/etc/nginx/cert.pem:ro
-      - $HOME/key.pem:/etc/nginx/key.pem:ro
+      - $HOME/docker_mirror_cache:/docker_mirror_cache
+      - $HOME/docker_mirror_certs:/ca
+    environment:
+      - REGISTRIES=nexus:8082
+      - AUTH_REGISTRIES=nexus:8082::admin::admin
+      - AUTH_REGISTRY_DELIMITER="::"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,12 @@ services:
     volumes:
       - $HOME/minio-data:$HOME/minio-data
     command: minio server $HOME/minio-data --console-address ":9001"
+
+  nginx:
+    image: nginx
+    restart: always
+    ports:
+      - "80:80" # HTTP
+      - "443:443" # HTTPS
+    volumes:
+      - $HOME/nginx.conf:/etc/nginx/nginx.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,5 +48,5 @@ services:
       - "443:443" # HTTPS
     volumes:
       - $HOME/nginx.conf:/etc/nginx/nginx.conf:ro
-      - $HOME/cert.cem:/etc/nginx/cert.pem:ro
-      - $HOME/key.cem:/etc/nginx/key.pem:ro
+      - $HOME/cert.pem:/etc/nginx/cert.pem:ro
+      - $HOME/key.pem:/etc/nginx/key.pem:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,3 +48,5 @@ services:
       - "443:443" # HTTPS
     volumes:
       - $HOME/nginx.conf:/etc/nginx/nginx.conf:ro
+      - $HOME/cert.cem:/etc/nginx/cert.pem:ro
+      - $HOME/key.cem:/etc/nginx/key.pem:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,5 +48,5 @@ services:
       - "443:443" # HTTPS
     volumes:
       - $HOME/nginx.conf:/etc/nginx/nginx.conf:ro
-      - $HOME/cert.pem:/etc/nginx/cert.pem:ro
+      - $HOME/cert.crt:/etc/nginx/cert.crt:ro
       - $HOME/key.pem:/etc/nginx/key.pem:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,26 +40,13 @@ services:
       - $HOME/minio-data:$HOME/minio-data
     command: minio server $HOME/minio-data --console-address ":9001"
 
-  # nginx:
-  #   image: nginx
-  #   restart: always
-  #   ports:
-  #     - "80:80" # HTTP
-  #     - "443:443" # HTTPS
-  #   volumes:
-  #     - $HOME/nginx.conf:/etc/nginx/nginx.conf:ro
-  #     - $HOME/cert.pem:/etc/nginx/cert.pem:ro
-  #     - $HOME/key.pem:/etc/nginx/key.pem:ro
-
-  docker-proxy:
-    image: tiangolo/docker-registry-proxy
+  nginx:
+    image: nginx
     restart: always
     ports:
-      - "3128:3128"
+      - "80:80" # HTTP
+      - "443:443" # HTTPS
     volumes:
-      - $HOME/docker_mirror_cache:/docker_mirror_cache
-      - $HOME/docker_mirror_certs:/ca
-    environment:
-      - REGISTRIES=nexus:8082
-      - AUTH_REGISTRIES=nexus:8082::admin::admin
-      - AUTH_REGISTRY_DELIMITER="::"
+      - $HOME/nginx.conf:/etc/nginx/nginx.conf:ro
+      - $HOME/cert.pem:/etc/nginx/cert.pem:ro
+      - $HOME/key.pem:/etc/nginx/key.pem:ro

--- a/website/docs/users/getting-started/configuration/nginx.md
+++ b/website/docs/users/getting-started/configuration/nginx.md
@@ -14,12 +14,12 @@ Then in your `nginx.conf` file, add the following to your server block:
 ```
 # send requests to the v1 docker API
 location /v1/ {
-  proxy_pass https://localhost:8082
+  proxy_pass https://localhost:8082;
 }
 
 # send requests to the v2 docker API
 location /v2/ {
-  proxy_pass https://localhost:8082
+  proxy_pass https://localhost:8082;
 }
 ```
 :::note
@@ -32,12 +32,12 @@ Hutch can use Nexus as a place to store Docker images. If you stand up a Nginx i
 ```
 # send requests to the v1 docker API
 location /v1/ {
-  proxy_pass https://my_nexus:8082
+  proxy_pass https://my_nexus:8082;
 }
 
 # send requests to the v2 docker API
 location /v2/ {
-  proxy_pass https://my_nexus:8082
+  proxy_pass https://my_nexus:8082;
 }
 ```
 

--- a/website/docs/users/getting-started/configuration/nginx.md
+++ b/website/docs/users/getting-started/configuration/nginx.md
@@ -1,0 +1,62 @@
+# (Optional) Proxying to host
+
+When running Hutch in a secure environment with no internet access, you will need to redirect links to some external resources to your internal equivalents.
+
+## Docker
+To redirect traffic to Docker to `localhost` / `127.0.0.1`, edit your `/etc/hosts` file by adding the following:
+
+```
+# Redirect WorkflowHub traffic
+127.0.0.1 index.docker.io
+```
+
+Then in your `nginx.conf` file, add the following to your server block:
+```
+# send requests to the v1 docker API
+location /v1/ {
+  proxy_pass https://localhost:8082
+}
+
+# send requests to the v2 docker API
+location /v2/ {
+  proxy_pass https://localhost:8082
+}
+```
+:::note
+This example assumes that you have your Docker replacement on port 8082 on your machine. Change it as necessary.
+:::
+
+### Nginx + Nexus using Docker Compose
+Hutch can use Nexus as a place to store Docker images. If you stand up a Nginx instance in Docker Compose along with your nexus instance, replace `localhost` in the above example with the name of your Nexus service, e.g.:
+
+```
+# send requests to the v1 docker API
+location /v1/ {
+  proxy_pass https://my_nexus:8082
+}
+
+# send requests to the v2 docker API
+location /v2/ {
+  proxy_pass https://my_nexus:8082
+}
+```
+
+The Docker Compose services might look like this:
+
+```yaml
+nexus:
+  image: sonatype/nexus3:3.52.0
+  restart: always
+  ports:
+    - "8081:8081" # web portal port
+    - "8082:8082" # port for the docker registry
+
+nginx:
+  image: nginx
+  restart: always
+  ports:
+    - "80:80" # HTTP
+    - "443:443" # HTTPS
+  volumes:
+    - /path/to/nginx.conf:/etc/nginx/nginx.conf:ro
+```

--- a/website/docs/users/getting-started/configuration/nginx.md
+++ b/website/docs/users/getting-started/configuration/nginx.md
@@ -12,9 +12,9 @@ To redirect traffic to WorkflowHub to `localhost` / `127.0.0.1`, edit your `/etc
 
 Then in your `nginx.conf` file, add the following to your server block:
 ```
-# rewrite and redirect the URL
-location = /workflows {
-  rewrite ^/([0-9]+)?version=[0-9]+$ http://nexus:8081/repository/hutchfiles/workflows/$1\.crate\.zip;
+# capture workflow ID and redirect the internal store
+location ~ ^\/workflows\/([0-9]+)?$ {
+  proxy_pass http://nexus:8081/repository/hutchfiles/workflows/$1.crate.zip;
 }
 ```
 
@@ -35,9 +35,14 @@ http {
     ssl_certificate /etc/nginx/cert.pem;
     ssl_certificate_key /etc/nginx/key.pem;
 
-    # rewrite and redirect the URL
-    location /workflows/ {
-      rewrite ^/([0-9]+)?version=[0-9]+$ $scheme://nexus:8081/repository/hutchfiles/workflows/$1\.crate\.zip break;
+    # capture workflow ID and redirect the internal store
+    location ~ ^\/workflows\/([0-9]+)$ {
+      proxy_pass http://nexus:8081/repository/hutchfiles/workflows/$1.crate.zip;
+    }
+
+    # root location must be defined for the set up to work
+    location / {
+      proxy_pass http://nexus:8081/service/rest/repository/browse/hutchfiles/;
     }
   }
 }

--- a/website/docs/users/getting-started/configuration/nginx.md
+++ b/website/docs/users/getting-started/configuration/nginx.md
@@ -59,4 +59,33 @@ nginx:
     - "443:443" # HTTPS
   volumes:
     - /path/to/nginx.conf:/etc/nginx/nginx.conf:ro
+    - /path/to/cert.pem:/etc/nginx/cert.pem:ro
+    - /path/to/key.pem:/etc/nginx/key.pem:ro
+```
+
+## Example `nginx.conf`
+```
+# nginx.conf
+events {
+  worker_connections  1024;
+}
+
+http {
+  server {
+    listen 443 ssl;
+    ssl_certificate /etc/nginx/cert.pem
+    ssl_certificate_key /etc/nginx/key.pem
+
+    # send requests to the v1 docker API
+    location /v1/ {
+      proxy_pass https://my_nexus:8082;
+    }
+
+    # send requests to the v2 docker API
+    location /v2/ {
+      proxy_pass https://my_nexus:8082;
+    }
+  }
+}
+
 ```

--- a/website/docs/users/getting-started/configuration/nginx.md
+++ b/website/docs/users/getting-started/configuration/nginx.md
@@ -1,8 +1,14 @@
 # (Optional) Proxying to host
 
+:::info
+This page assumes you are using Ubuntu Linux as your OS.
+:::
+
 When running Hutch in a secure environment with no internet access, you will need to redirect links to some external resources to your internal equivalents.
 
 ## WorkflowHub
+
+### Re-routing traffic to `localhost`
 To redirect traffic to WorkflowHub to `localhost` / `127.0.0.1`, edit your `/etc/hosts` file by adding the following:
 
 ```
@@ -10,6 +16,34 @@ To redirect traffic to WorkflowHub to `localhost` / `127.0.0.1`, edit your `/etc
 127.0.0.1 workflowhub.eu
 ```
 
+### Trust issues
+To get Hutch to trust calls to the redirected traffic, you need to generate a self-signed SSL certificate and add it to your machine's trust store.
+
+1. Generate the certificate.
+
+```bash
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.crt -sha256 -days 365
+```
+:::info
+You will be asked for some information about your organisation etc. Most of this can be left blank except for the "Common Name" which **must** be set to `workflowhub.eu`.
+
+:::
+2. Decrypt your private key.
+
+```bash
+openssl rsa -in key.pem -out new-key.pem && mv new-key.pem key.pem 
+```
+
+3. Add the certificate to trust store.
+
+```bash
+cp cert.crt /usr/share/ca-certificates/cert.crt
+```
+:::info
+This command should be executed as `root`.
+:::
+
+### Re-routing to the workflow store
 Then in your `nginx.conf` file, add the following to your server block:
 ```
 # capture workflow ID and redirect the internal store
@@ -32,7 +66,7 @@ events {
 http {
   server {
     listen 443 ssl;
-    ssl_certificate /etc/nginx/cert.pem;
+    ssl_certificate /etc/nginx/cert.crt;
     ssl_certificate_key /etc/nginx/key.pem;
 
     # capture workflow ID and redirect the internal store
@@ -46,5 +80,4 @@ http {
     }
   }
 }
-
 ```

--- a/website/docs/users/getting-started/configuration/nginx.md
+++ b/website/docs/users/getting-started/configuration/nginx.md
@@ -13,7 +13,7 @@ To redirect traffic to WorkflowHub to `localhost` / `127.0.0.1`, edit your `/etc
 Then in your `nginx.conf` file, add the following to your server block:
 ```
 # capture workflow ID and redirect the internal store
-location ~ ^\/workflows\/([0-9]+)?$ {
+location ~ ^\/workflows\/([0-9]+)\/ro_crate$ {
   proxy_pass http://nexus:8081/repository/hutchfiles/workflows/$1.crate.zip;
 }
 ```
@@ -36,7 +36,7 @@ http {
     ssl_certificate_key /etc/nginx/key.pem;
 
     # capture workflow ID and redirect the internal store
-    location ~ ^\/workflows\/([0-9]+)$ {
+    location ~ ^\/workflows\/([0-9]+)\/ro_crate$ {
       proxy_pass http://nexus:8081/repository/hutchfiles/workflows/$1.crate.zip;
     }
 

--- a/website/docs/users/getting-started/configuration/nginx.md
+++ b/website/docs/users/getting-started/configuration/nginx.md
@@ -7,7 +7,7 @@ To redirect traffic to Docker to `localhost` / `127.0.0.1`, edit your `/etc/host
 
 ```
 # Redirect WorkflowHub traffic
-127.0.0.1 index.docker.io
+127.0.0.1 registry-1.docker.io
 ```
 
 Then in your `nginx.conf` file, add the following to your server block:


### PR DESCRIPTION
## Overview

Documentation for setting up a TRE to look for WorkflowHub workflows locally instead of over the internet.

## Azure Boards

- AB#108960
- AB#108963
- AB#108964
- AB#108961

## Notes

The branch name is docker-redirects because I started on that then switched to workflows. The docker stuff will be in a separate PR.
