### PR TITLE
AB#113151: Can't pull rquest-omop-worker from GH repo

### DIFF
--- a/workflows/rquest-oneshot.cwl
+++ b/workflows/rquest-oneshot.cwl
@@ -5,7 +5,7 @@ label: rquest-oneshot
 
 hints:
     DockerRequirement:
-        dockerPull: ghcr.io/hdruk/hutch/rquest-omop-worker:next
+        dockerPull: hutchstack/rquest-omop-worker:next
 
 requirements:
     EnvVarRequirement:

--- a/workflows/rquest-oneshotx86.cwl
+++ b/workflows/rquest-oneshotx86.cwl
@@ -5,7 +5,7 @@ label: rquest-oneshot
 
 hints:
     DockerRequirement:
-        dockerPull: ghcr.io/hdruk/hutch/rquest-omop-worker:next
+        dockerPull: hutchstack/rquest-omop-worker:next
 requirements:
     EnvVarRequirement:
         envDef:


### PR DESCRIPTION
## Overview

Use Docker Hub images for `rquest-omop-agent` since the Github ones are private and we can't change the permissions.

## Azure Boards

- AB#113152
- AB#113153
- AB#113154
- AB#113156
