### PR TITLE
AB#113463: Fix GitHub workflows to publish docker images to docker hub

### DIFF
--- a/.github/workflows/publish.rquest-omop-worker.yml
+++ b/.github/workflows/publish.rquest-omop-worker.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: release
   push:
-    branches: [main, push-to-docker-hub]
+    branches: [main]
 
 jobs:
   generate-timestamp:

--- a/.github/workflows/publish.rquest-omop-worker.yml
+++ b/.github/workflows/publish.rquest-omop-worker.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: release
   push:
-    branches: [main]
+    branches: [main, push-to-docker-hub]
 
 jobs:
   generate-timestamp:
@@ -31,7 +31,7 @@ jobs:
       APP_NAME: rquest-omop-worker
       NEXT_TAG: next
       TS_TAG: ${{ needs.generate-timestamp.outputs.timestamp }}
-      REGISTRY: ghcr.io
+      REGISTRY: hutchstack
     needs: generate-timestamp
     steps:
       - uses: actions/checkout@v2
@@ -39,15 +39,14 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@v2.0.0
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.HUTCHSTACK_USER }}
+          password: ${{ secrets.HUTCHSTACK_PASSWORD }}
 
       - name: Docker Metadata action
         id: meta
         uses: docker/metadata-action@v4.0.1
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.APP_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.APP_NAME }}
           tags: |
             ${{ env.TS_TAG }}
             ${{ env.NEXT_TAG }}

--- a/.github/workflows/release.rquest-omop-worker.yml
+++ b/.github/workflows/release.rquest-omop-worker.yml
@@ -38,22 +38,21 @@ jobs:
       packages: write
     env:
       APP_NAME: rquest-omop-worker
-      REGISTRY: ghcr.io
+      REGISTRY: hutchstack
     steps:
       - uses: actions/checkout@v2
 
       - name: Docker Login
         uses: docker/login-action@v2.0.0
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.HUTCHSTACK_USER }}
+          password: ${{ secrets.HUTCHSTACK_PASSWORD }}
 
       - name: Docker Metadata action
         id: meta
         uses: docker/metadata-action@v4.0.1
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.APP_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.APP_NAME }}
           tags: |
             stable
             ${{ needs.get-version.outputs.VERSION_TAG }}


### PR DESCRIPTION
## Overview

Docker images for the `rquest-omop-worker` now push to docker hub instead of github.

## Azure Boards

- AB#113583
- AB#113584
- AB#113585
- AB#113586
