### PR TITLE
AB#98893: Initialising RO-Crates

### DIFF
--- a/lib/ROCrates.Net.Tests/Fixtures/test-compound-types.json
+++ b/lib/ROCrates.Net.Tests/Fixtures/test-compound-types.json
@@ -1,0 +1,72 @@
+{
+  "@context": "https://w3id.org/ro/crate/1.1/context",
+  "@graph": [
+    {
+      "@id": "ro-crate-metadata.json",
+      "@type": "CreativeWork",
+      "conformsTo": {
+        "@id": "https://w3id.org/ro/crate/1.1"
+      },
+      "about": {
+        "@id": "./"
+      }
+    },
+    {
+      "@id": "ro-crate-preview.html",
+      "@type": "CreativeWork",
+      "about": {
+        "@id": "./"
+      }
+    },
+    {
+      "@id": "./",
+      "@type": "Dataset",
+      "datePublished": "04/04/2023 14:08:13",
+      "hasPart": [
+        {
+          "@id": "alignment.knime"
+        }
+      ]
+    },
+    {
+      "@id": "alignment.knime",
+      "@type": [
+        "File",
+        "SoftwareSourceCode",
+        "ComputationalWorkflow"
+      ],
+      "conformsTo": {
+        "@id": "https://bioschemas.org/profiles/ComputationalWorkflow/0.5-DRAFT-2020_07_21/"
+      },
+      "name": "Sequence alignment workflow",
+      "programmingLanguage": {
+        "@id": "#knime"
+      },
+      "creator": {
+        "@id": "#alice"
+      },
+      "dateCreated": "2020-05-23",
+      "license": {
+        "@id": "https://spdx.org/licenses/CC-BY-NC-SA-4.0"
+      },
+      "input": [
+        {
+          "@id": "#36aadbd4-4a2d-4e33-83b4-0cbf6a6a8c5b"
+        }
+      ],
+      "output": [
+        {
+          "@id": "#6c703fee-6af7-4fdb-a57d-9e8bc4486044"
+        },
+        {
+          "@id": "#2f32b861-e43c-401f-8c42-04fd84273bdf"
+        }
+      ],
+      "sdPublisher": {
+        "@id": "#workflow-hub"
+      },
+      "url": "http://example.com/workflows/alignment",
+      "version": "0.5.0"
+    }
+  ]
+}

--- a/lib/ROCrates.Net.Tests/Fixtures/test-invalid-metadata.json
+++ b/lib/ROCrates.Net.Tests/Fixtures/test-invalid-metadata.json
@@ -1,0 +1,48 @@
+{
+  "@context": "https://w3id.org/ro/crate/1.1/context",
+  "@graph": [
+    {
+      "@id": "ro-crate-metadata.json",
+      "@type": "CreativeWork",
+      "conformsTo": {
+        "@id": "https://w3id.org/ro/crate/1.1"
+      },
+      "about": {
+        "@id": "./"
+      }
+    },
+    {
+      "@id": "ro-crate-preview.html",
+      "@type": "CreativeWork",
+      "about": {
+        "@id": "./"
+      }
+    },
+    {
+      "@id": "./",
+      "@type": "Dataset",
+      "datePublished": "04/04/2023 14:08:13",
+      "hasPart": [
+        {
+          "@id": "cp7glop.ai"
+        },
+        {
+          "@id": "lots_of_little_files/"
+        }
+      ]
+    },
+    {
+      "name": "Diagram showing trend to increase",
+      "contentSize": "383766",
+      "description": "Illustrator file for Glop Pot",
+      "encodingFormat": "application/pdf"
+    },
+    {
+      "@id": "lots_of_little_files/",
+      "@type": "Dataset",
+      "name": "Too many files",
+      "description": "This directory contains many small files, that we're not going to describe in detail.",
+      "datePublished": "04/03/2023 15:04:26"
+    }
+  ]
+}

--- a/lib/ROCrates.Net.Tests/TestDataset.cs
+++ b/lib/ROCrates.Net.Tests/TestDataset.cs
@@ -20,7 +20,7 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
     var sourceDir = Path.Combine(_testDatasetFixture.TestBasePath, _testDirName);
     Directory.CreateDirectory(sourceDir);
     var dataset = new Models.Dataset(
-      new ROCrate(_testDirName),
+      new ROCrate(),
       source: Path.Combine(_testDatasetFixture.TestBasePath, _testDirName));
 
     // Act
@@ -39,7 +39,7 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
     Directory.CreateDirectory(sourceDir);
     Directory.CreateDirectory(destPath);
     var dataset = new Models.Dataset(
-      new ROCrate(_testDirName),
+      new ROCrate(),
       source: Path.Combine(_testDatasetFixture.TestBasePath, _testDirName),
       destPath: destPath);
 
@@ -57,7 +57,7 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
     var testDestPath = Path.Combine(_testDatasetFixture.TestBasePath, "ext", _testDirName);
     Directory.CreateDirectory(testDestPath);
     var dataset = new Models.Dataset(
-      new ROCrate(_testDirName),
+      new ROCrate(),
       source: Path.Combine("non", "existent"),
       destPath: testDestPath);
 

--- a/lib/ROCrates.Net.Tests/TestFileOrDir.cs
+++ b/lib/ROCrates.Net.Tests/TestFileOrDir.cs
@@ -16,15 +16,14 @@ public class TestFileOrDir
   public void Test_ConstructorThrows_When_DestPathIsAbsolute()
   {
     Assert.Throws<Exception>(() => new FileOrDir(
-      new ROCrate("my-test.zip"),
+      new ROCrate(),
       destPath: "/path/to/dest"));
   }
 
   [Fact]
   public void Test_Identifier_DefaultsTo_DotSlash()
   {
-    var dataEntity = new FileOrDir(
-      new ROCrate("my-test.zip"));
+    var dataEntity = new FileOrDir(new ROCrate());
     Assert.Equal("./", dataEntity.Id);
   }
 
@@ -37,10 +36,10 @@ public class TestFileOrDir
 
     // Act
     var dataEntityWithLocal = new FileOrDir(
-      new ROCrate("my-test.zip"),
+      new ROCrate(),
       source: localName);
     var dataEntityWithRemote = new FileOrDir(
-      new ROCrate("my-test.zip"),
+      new ROCrate(),
       source: remoteName,
       fetchRemote: true);
 
@@ -57,7 +56,7 @@ public class TestFileOrDir
 
     // Act
     var dataEntityWithDir = new FileOrDir(
-      new ROCrate("my-test.zip"),
+      new ROCrate(),
       source: dirName);
 
     // Assert

--- a/lib/ROCrates.Net.Tests/TestPreview.cs
+++ b/lib/ROCrates.Net.Tests/TestPreview.cs
@@ -1,11 +1,7 @@
-using System.Text.Json.Nodes;
-using ROCrates.Models;
-
 namespace ROCrates.Tests;
 
 public class TestPreview : IClassFixture<TestPreviewFixture>
 {
-  private ROCrate _roCrate = new();
   private readonly TestPreviewFixture _testPreviewFixture;
 
   public TestPreview(TestPreviewFixture testPreviewFixture)
@@ -17,14 +13,10 @@ public class TestPreview : IClassFixture<TestPreviewFixture>
   public void TestWrite_Creates_PreviewFile()
   {
     // Arrange
-    var previewJson = System.IO.File.ReadAllText("Fixtures/test-preview.json").TrimEnd();
-    var previewProperties = JsonNode.Parse(previewJson).AsObject();
-    var preview = new Preview(_roCrate, properties: previewProperties);
-
-    _roCrate.Preview = preview;
+    var roCrate = new ROCrate();
 
     // Act
-    preview.Write(Path.GetDirectoryName(_testPreviewFixture.OutputPath));
+    roCrate.Preview.Write(Path.GetDirectoryName(_testPreviewFixture.OutputPath));
 
     // Assert
     Assert.True(System.IO.File.Exists(_testPreviewFixture.OutputPath));

--- a/lib/ROCrates.Net.Tests/TestPreview.cs
+++ b/lib/ROCrates.Net.Tests/TestPreview.cs
@@ -17,16 +17,11 @@ public class TestPreview : IClassFixture<TestPreviewFixture>
   public void TestWrite_Creates_PreviewFile()
   {
     // Arrange
-    var rootJson = System.IO.File.ReadAllText("Fixtures/test-root-dataset.json").TrimEnd();
-    var rootProperties = JsonNode.Parse(rootJson).AsObject();
-    var rootDataset = new RootDataset(_roCrate, properties: rootProperties);
-
     var previewJson = System.IO.File.ReadAllText("Fixtures/test-preview.json").TrimEnd();
     var previewProperties = JsonNode.Parse(previewJson).AsObject();
     var preview = new Preview(_roCrate, properties: previewProperties);
 
-
-    _roCrate.Add(rootDataset, preview);
+    _roCrate.Preview = preview;
 
     // Act
     preview.Write(Path.GetDirectoryName(_testPreviewFixture.OutputPath));

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -195,7 +195,7 @@ public class TestRoCrate
     var action = () => roCrate.Initialise(testDir.FullName);
 
     // Assert
-    Assert.Throws<CrateReadException>(action);
+    Assert.Throws<MetadataException>(action);
 
     // Clean up
     if (testDir.Exists) testDir.Delete(recursive: true);
@@ -242,6 +242,32 @@ public class TestRoCrate
 
     // Assert
     Assert.Throws<MetadataException>(action);
+
+    // Clean up
+    if (testDir.Exists) testDir.Delete(recursive: true);
+  }
+
+  [Fact]
+  public void Initialise_Reads_EntitiesToROCrateObject()
+  {
+    // Arrange
+    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+    testDir.Create();
+    System.IO.File.Copy(
+      "Fixtures/metadata-test.json",
+      Path.Combine(testDir.FullName, "ro-crate-metadata.json")
+    );
+    var roCrate = new ROCrate();
+
+    // Act
+    roCrate.Initialise(testDir.FullName);
+
+    // Assert
+    Assert.Contains("./", roCrate.Entities.Keys);
+    Assert.Contains("ro-crate-metadata.json", roCrate.Entities.Keys);
+    Assert.Contains("ro-crate-preview.html", roCrate.Entities.Keys);
+    Assert.Contains("cp7glop.ai", roCrate.Entities.Keys);
+    Assert.Contains("lots_of_little_files/", roCrate.Entities.Keys);
 
     // Clean up
     if (testDir.Exists) testDir.Delete(recursive: true);

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -202,7 +202,7 @@ public class TestRoCrate
   }
 
   [Fact]
-  public void Initialise_Throws_WhenMetadataMissingContextAndGraph()
+  public void Initialise_Throws_WhenMetadataMissingContentAndGraph()
   {
     // Arrange
     var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
@@ -219,7 +219,7 @@ public class TestRoCrate
     var action = () => roCrate.Initialise(testDir.FullName);
 
     // Assert
-    Assert.Throws<CrateReadException>(action);
+    Assert.Throws<MetadataException>(action);
 
     // Clean up
     if (testDir.Exists) testDir.Delete(recursive: true);

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -272,4 +272,29 @@ public class TestRoCrate
     // Clean up
     if (testDir.Exists) testDir.Delete(recursive: true);
   }
+
+  [Fact]
+  public void Initialise_Reads_ObjectsWithCompoundTypes()
+  {
+    // Arrange
+    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+    testDir.Create();
+    System.IO.File.Copy(
+      "Fixtures/test-compound-types.json",
+      Path.Combine(testDir.FullName, "ro-crate-metadata.json")
+    );
+    var roCrate = new ROCrate();
+
+    // Act
+    roCrate.Initialise(testDir.FullName);
+
+    // Assert
+    Assert.Contains("./", roCrate.Entities.Keys);
+    Assert.Contains("ro-crate-metadata.json", roCrate.Entities.Keys);
+    Assert.Contains("ro-crate-preview.html", roCrate.Entities.Keys);
+    Assert.Contains("alignment.knime", roCrate.Entities.Keys);
+
+    // Clean up
+    if (testDir.Exists) testDir.Delete(recursive: true);
+  }
 }

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -321,8 +321,31 @@ public class TestRoCrate
   public void Convert_Creates_ROCrateWithAllEntities()
   {
     // Arrange
+    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+    testDir.Create();
+    var subDir = testDir.CreateSubdirectory(Guid.NewGuid().ToString());
+    var topLevelFile = new FileInfo($"{Guid.NewGuid().ToString()}.json");
+    topLevelFile.Create().Close();
+    topLevelFile.MoveTo(Path.Combine(testDir.FullName, topLevelFile.Name));
+    var subDirFile = new FileInfo($"{Guid.NewGuid().ToString()}.json");
+    subDirFile.Create().Close();
+    subDirFile.MoveTo(Path.Combine(subDir.FullName, subDirFile.Name));
+    var roCrate = new ROCrate();
+
     // Act
+    roCrate.Convert(testDir.FullName);
+
     // Assert
+    Assert.Contains(topLevelFile.Name, roCrate.Entities.Keys);
+    Assert.Contains(
+      Path.GetRelativePath(
+        testDir.FullName,
+        subDir.FullName
+      ) + "/",
+      roCrate.Entities.Keys
+    );
+
     // Clean up
+    if (testDir.Exists) testDir.Delete(recursive: true);
   }
 }

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -297,4 +297,32 @@ public class TestRoCrate
     // Clean up
     if (testDir.Exists) testDir.Delete(recursive: true);
   }
+
+  [Fact]
+  public void Convert_Creates_PreviewAndMetadata()
+  {
+    // Arrange
+    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+    testDir.Create();
+    var roCrate = new ROCrate();
+
+    // Act
+    roCrate.Convert(testDir.FullName);
+
+    // Assert
+    Assert.True(System.IO.File.Exists(Path.Combine(testDir.FullName, roCrate.Metadata.Id)));
+    Assert.True(System.IO.File.Exists(Path.Combine(testDir.FullName, roCrate.Preview.Id)));
+
+    // Clean up
+    if (testDir.Exists) testDir.Delete(recursive: true);
+  }
+
+  [Fact]
+  public void Convert_Creates_ROCrateWithAllEntities()
+  {
+    // Arrange
+    // Act
+    // Assert
+    // Clean up
+  }
 }

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -224,4 +224,26 @@ public class TestRoCrate
     // Clean up
     if (testDir.Exists) testDir.Delete(recursive: true);
   }
+
+  [Fact]
+  public void Initialise_Throws_WhenGraphElementIsInvalid()
+  {
+    // Arrange
+    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+    testDir.Create();
+    System.IO.File.Copy(
+      "Fixtures/test-invalid-metadata.json",
+      Path.Combine(testDir.FullName, "ro-crate-metadata.json")
+    );
+    var roCrate = new ROCrate();
+
+    // Act
+    var action = () => roCrate.Initialise(testDir.FullName);
+
+    // Assert
+    Assert.Throws<MetadataException>(action);
+
+    // Clean up
+    if (testDir.Exists) testDir.Delete(recursive: true);
+  }
 }

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+using ROCrates.Exceptions;
 using ROCrates.Models;
 using File = ROCrates.Models.File;
 
@@ -143,7 +143,7 @@ public class TestRoCrate
     var action = () => roCrate.Initialise(testDir.FullName);
 
     // Assert
-    Assert.Throws<FileNotFoundException>(action);
+    Assert.Throws<CrateReadException>(action);
 
     // Clean up
     if (testDir.Exists) testDir.Delete(recursive: true);
@@ -160,7 +160,7 @@ public class TestRoCrate
     var action = () => roCrate.Initialise(testDir.FullName);
 
     // Assert
-    Assert.Throws<DirectoryNotFoundException>(action);
+    Assert.Throws<CrateReadException>(action);
   }
 
   [Fact]
@@ -175,7 +175,7 @@ public class TestRoCrate
     var action = () => roCrate.Initialise(testFile.FullName);
 
     // Assert
-    Assert.Throws<DirectoryNotFoundException>(action);
+    Assert.Throws<CrateReadException>(action);
 
     // Clean up
     if (testFile.Exists) testFile.Delete();
@@ -195,7 +195,7 @@ public class TestRoCrate
     var action = () => roCrate.Initialise(testDir.FullName);
 
     // Assert
-    Assert.Throws<JsonException>(action);
+    Assert.Throws<CrateReadException>(action);
 
     // Clean up
     if (testDir.Exists) testDir.Delete(recursive: true);
@@ -219,7 +219,7 @@ public class TestRoCrate
     var action = () => roCrate.Initialise(testDir.FullName);
 
     // Assert
-    Assert.Throws<InvalidDataException>(action);
+    Assert.Throws<CrateReadException>(action);
 
     // Clean up
     if (testDir.Exists) testDir.Delete(recursive: true);

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -11,7 +11,7 @@ public class TestRoCrate
   {
     string validUrl = "https://doi.org/10.4225/59/59672c09f4a4b";
     string invalidUrl = "https://do i.org/10.4225/59/59672c09f4a4b";
-    var crate = new ROCrate("my-test.zip");
+    var crate = new ROCrate();
 
     string resultValidUrl = crate.ResolveId(validUrl);
     Assert.Equal(validUrl, resultValidUrl);

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -22,36 +22,6 @@ public class TestRoCrate
   }
 
   [Fact]
-  public void Add_Adds_RootDataset()
-  {
-    var roCrate = new ROCrate();
-    var rootDataset = new RootDataset(roCrate);
-
-    roCrate.Add(rootDataset);
-    Assert.Equal(roCrate.RootDataset.Id, rootDataset.Id);
-    Assert.Equal(roCrate.RootDataset.Properties, rootDataset.Properties);
-
-    Assert.True(roCrate.Entities.ContainsKey(rootDataset.GetCanonicalId()));
-    Assert.True(roCrate.Entities.TryGetValue(rootDataset.GetCanonicalId(), out var recoveredRootDataset));
-    Assert.IsType<RootDataset>(recoveredRootDataset);
-  }
-
-  [Fact]
-  public void Add_Adds_Metadata()
-  {
-    var roCrate = new ROCrate();
-    var metadata = new Metadata(roCrate);
-
-    roCrate.Add(metadata);
-    Assert.Equal(roCrate.Metadata.Id, metadata.Id);
-    Assert.Equal(roCrate.Metadata.Properties, metadata.Properties);
-
-    Assert.True(roCrate.Entities.ContainsKey(metadata.GetCanonicalId()));
-    Assert.True(roCrate.Entities.TryGetValue(metadata.GetCanonicalId(), out var recoveredMetadata));
-    Assert.IsType<Metadata>(recoveredMetadata);
-  }
-
-  [Fact]
   public void Add_Adds_ObjetsOfDifferentTypes()
   {
     var roCrate = new ROCrate();

--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -137,4 +137,54 @@ public class TestRoCrate
     if (Directory.Exists(outputDir)) Directory.Delete(outputDir, recursive: true);
     if (System.IO.File.Exists(outputZipFile)) System.IO.File.Delete(outputZipFile);
   }
+
+  [Fact]
+  public void Initialise_Throws_WithNoMetadataJsonFile()
+  {
+    // Arrange
+    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+    testDir.Create();
+    var roCrate = new ROCrate();
+
+    // Act
+    var action = () => roCrate.Initialise(testDir.FullName);
+
+    // Assert
+    Assert.Throws<FileNotFoundException>(action);
+
+    // Clean up
+    if (testDir.Exists) testDir.Delete(recursive: true);
+  }
+
+  [Fact]
+  public void Initialise_Throws_WhenSourceNonExistent()
+  {
+    // Arrange
+    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+    var roCrate = new ROCrate();
+
+    // Act
+    var action = () => roCrate.Initialise(testDir.FullName);
+
+    // Assert
+    Assert.Throws<DirectoryNotFoundException>(action);
+  }
+
+  [Fact]
+  public void Initialise_Throws_WhenSourceIsNotADirectory()
+  {
+    // Arrange
+    var testFile = new FileInfo(Guid.NewGuid().ToString());
+    testFile.Create();
+    var roCrate = new ROCrate();
+
+    // Act
+    var action = () => roCrate.Initialise(testFile.FullName);
+
+    // Assert
+    Assert.Throws<DirectoryNotFoundException>(action);
+
+    // Clean up
+    if (testFile.Exists) testFile.Delete();
+  }
 }

--- a/lib/ROCrates.Net/Exceptions/CrateReadException.cs
+++ b/lib/ROCrates.Net/Exceptions/CrateReadException.cs
@@ -1,0 +1,19 @@
+namespace ROCrates.Exceptions;
+
+/// <summary>
+/// An exception that can be thrown whenever an RO-crate cannot be read.
+/// </summary>
+public class CrateReadException : Exception
+{
+  public CrateReadException()
+  {
+  }
+
+  public CrateReadException(string? message, Exception? innerException) : base(message, innerException)
+  {
+  }
+
+  public CrateReadException(string? message) : base(message)
+  {
+  }
+}

--- a/lib/ROCrates.Net/Exceptions/CrateReadException.cs
+++ b/lib/ROCrates.Net/Exceptions/CrateReadException.cs
@@ -1,3 +1,5 @@
+using System.Runtime.Serialization;
+
 namespace ROCrates.Exceptions;
 
 /// <summary>
@@ -14,6 +16,10 @@ public class CrateReadException : Exception
   }
 
   public CrateReadException(string? message) : base(message)
+  {
+  }
+
+  protected CrateReadException(SerializationInfo info, StreamingContext context) : base(info, context)
   {
   }
 }

--- a/lib/ROCrates.Net/Exceptions/MetadataException.cs
+++ b/lib/ROCrates.Net/Exceptions/MetadataException.cs
@@ -1,0 +1,28 @@
+using System.Runtime.Serialization;
+
+namespace ROCrates.Exceptions;
+
+/// <summary>
+/// <para>An error that should be thrown when something is wrong with an RO-Crate's metadata.</para>
+/// <para>It should be used when the deserialised metadata JSON is invalid,
+/// not when there is an issue reading the <c>ro-crate-metadata.json</c> file.
+/// </para>
+/// </summary>
+public class MetadataException : Exception
+{
+  public MetadataException()
+  {
+  }
+
+  protected MetadataException(SerializationInfo info, StreamingContext context) : base(info, context)
+  {
+  }
+
+  public MetadataException(string? message) : base(message)
+  {
+  }
+
+  public MetadataException(string? message, Exception? innerException) : base(message, innerException)
+  {
+  }
+}

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -13,16 +13,16 @@ public class Dataset : FileOrDir
     source, destPath, fetchRemote, validateUrl)
   {
     DefaultType = "Dataset";
+    Id = _formatIdentifier(Id);
     Properties = _empty();
     if (properties is not null) _unpackProperties(properties);
-    Id = _formatIdentifier(Id);
   }
 
   public Dataset()
   {
     DefaultType = "Dataset";
-    Properties = _empty();
     Id = _formatIdentifier(Id);
+    Properties = _empty();
   }
 
   /// <summary>

--- a/lib/ROCrates.Net/Models/Metadata.cs
+++ b/lib/ROCrates.Net/Models/Metadata.cs
@@ -42,7 +42,7 @@ public class Metadata : File
   {
     // Iterate through the entities in the RO-Crate, extract their properties and serialise to JSON.
     var crateJson = new JsonObject { { "@context", "https://w3id.org/ro/crate/1.1/context" } };
-    var graphArray = new JsonArray { JsonNode.Parse(Serialize()), JsonNode.Parse(RoCrate.Preview.Serialize()) };
+    var graphArray = new JsonArray();
 
     foreach (var entity in RoCrate.Entities)
     {

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -32,13 +32,6 @@ public class ROCrate
     Preview = new Preview(this);
   }
 
-  public ROCrate(string source)
-  {
-    RootDataset = new RootDataset(this);
-    Metadata = new Metadata(this);
-    Preview = new Preview(this);
-  }
-
   /// <summary>
   /// Resolves URI for a given ID.
   /// </summary>

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -303,7 +303,11 @@ public class ROCrate
   }
 
   /// <summary>
-  /// Initialise an <c>ROCrate</c> object from the contents of a directory that is a valid RO-Crate.
+  /// <para>Initialise an <c>ROCrate</c> object from the contents of a directory that is a valid RO-Crate.</para>
+  /// <para>
+  /// This method assumes that all files and directories described by the metadata exist on disk.
+  /// It will not fetch them from remote locations.
+  /// </para>
   /// </summary>
   /// <param name="source">
   /// The path to the directory containing the RO-Crate to initialise an <c>ROCrate</c> from.
@@ -346,16 +350,16 @@ public class ROCrate
     foreach (var g in graph)
     {
       if (g?["@type"] is null || g["@id"] is null) throw new MetadataException("Invalid element in @graph.");
-      var type = g["@type"]!.ToString();
+      var type = g["@type"]!.ToJsonString();
       switch (type)
       {
-        case "ComputationalWorkflow":
-          Add(new ComputationalWorkflow(this, g["@id"]!.ToString(), g.AsObject()));
+        case @"[""File"",""SoftwareSourceCode"",""ComputationalWorkflow""]":
+          Add(new ComputationalWorkflow(this, source: g["@id"]!.ToString(), properties: g.AsObject()));
           break;
-        case "ComputerLanguage":
+        case @"""ComputerLanguage""":
           Add(new ComputerLanguage(this, g["@id"]!.ToString(), g.AsObject()));
           break;
-        case "CreativeWork":
+        case @"""CreativeWork""":
           switch (g["@id"]!.ToString())
           {
             case "ro-crate-metadata.json":
@@ -376,37 +380,37 @@ public class ROCrate
           }
 
           break;
-        case "Dataset":
+        case @"""Dataset""":
           Add(g["@id"]!.ToString() == "./"
             ? new RootDataset(this, source: g["@id"]!.ToString(), properties: g.AsObject())
             : new Dataset(this, source: g["@id"]!.ToString(), properties: g.AsObject()));
 
           break;
-        case "File":
+        case @"""File""":
           Add(new File(this, source: g["@id"]!.ToString(), properties: g.AsObject()));
           break;
-        case "Person":
+        case @"""Person""":
           Add(new Person(this, g["@id"]!.ToString(), g.AsObject()));
           break;
-        case "SoftwareApplication":
+        case @"""SoftwareApplication""":
           Add(new SoftwareApplication(this, g["@id"]!.ToString(), g.AsObject()));
           break;
-        case "TestDefinition":
+        case @"""TestDefinition""":
           Add(new TestDefinition(this, source: g["@id"]!.ToString(), properties: g.AsObject()));
           break;
-        case "TestInstance":
+        case @"""TestInstance""":
           Add(new TestInstance(this, g["@id"]!.ToString(), g.AsObject()));
           break;
-        case "TestService":
+        case @"""TestService""":
           Add(new TestService(this, g["@id"]!.ToString(), g.AsObject()));
           break;
-        case "TestSuite":
+        case @"""TestSuite""":
           Add(new TestSuite(this, g["@id"]!.ToString(), g.AsObject()));
           break;
-        case "Workflow":
+        case @"[""File"",""SoftwareSourceCode"",""Workflow""]":
           Add(new Workflow(this, source: g["@id"]!.ToString(), properties: g.AsObject()));
           break;
-        case "WorkflowDescription":
+        case @"[""File"",""SoftwareSourceCode"",""WorkflowDescription""]":
           Add(new WorkflowDescription(this, source: g["@id"]!.ToString(), properties: g.AsObject()));
           break;
         default:

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -14,12 +14,6 @@ public class ROCrate
   private static string _uuid = Guid.NewGuid().ToString();
   private string _arcpBaseUri = $"arcp://uuid,{_uuid}/";
 
-  private string _source = string.Empty;
-
-  private List<string> _exclude = new();
-  private bool _generatePreview;
-  private bool _init;
-
   public RootDataset RootDataset;
   public Metadata Metadata;
   public Preview Preview;
@@ -37,12 +31,8 @@ public class ROCrate
     Preview = new Preview(this);
   }
 
-  public ROCrate(string source, bool generatePreview = false, bool init = false, List<string>? exclude = null)
+  public ROCrate(string source)
   {
-    _source = source;
-    _generatePreview = generatePreview;
-    _init = init;
-    if (exclude is not null) _exclude = exclude;
     RootDataset = new RootDataset(this);
     Metadata = new Metadata(this);
     Preview = new Preview(this);

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -330,13 +330,13 @@ public class ROCrate
       select g;
     var metadataProperties = filteredGraph.First().AsObject();
 
-    if (metadataProperties is null) throw new CrateReadException("Could not find the metadata properties.");
+    if (metadataProperties is null) throw new MetadataException("Could not find the metadata properties.");
     Metadata.Properties = metadataProperties;
 
     // Add objects to the crate
     foreach (var g in graph)
     {
-      if (g?["@type"] is null || g["@id"] is null) throw new CrateReadException("Invalid element in @graph.");
+      if (g?["@type"] is null || g["@id"] is null) throw new MetadataException("Invalid element in @graph.");
       var type = g["@type"]!.ToString();
       switch (type)
       {

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -300,4 +300,15 @@ public class ROCrate
     ZipFile.CreateFromDirectory(saveLocation, $"{saveLocation}.zip");
     Directory.Delete(saveLocation, recursive: true);
   }
+
+  public void Initialise(string source)
+  {
+    if (!Directory.Exists(source))
+      throw new DirectoryNotFoundException($"{source} does not exist or is not a directory.");
+
+    if (!System.IO.File.Exists(Path.Combine(source, "ro-crate-metadata.json")))
+      throw new FileNotFoundException(
+        $@"Metadata file not found in {source}. If you would like this to be an RO-Crate, use Convert to convert it."
+      );
+  }
 }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -440,6 +440,7 @@ public class ROCrate
   {
     var dirInfo = new DirectoryInfo(source);
 
+    // Add directories and files contained in those directories
     foreach (var dir in dirInfo.EnumerateDirectories("*", SearchOption.AllDirectories))
     {
       var dataset = AddDataset(source: Path.GetRelativePath(dirInfo.FullName, dir.FullName));
@@ -448,6 +449,12 @@ public class ROCrate
         var file = AddFile(source: fileInfo.Name);
         dataset.AppendTo("hasPart", file);
       }
+    }
+
+    // Add files in the top level of `source`
+    foreach (var f in dirInfo.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
+    {
+      AddFile(source: f.Name);
     }
 
     Metadata.Write(source);

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -27,9 +27,14 @@ public class ROCrate
   /// </summary>
   public ROCrate()
   {
-    RootDataset = new RootDataset(this);
     Metadata = new Metadata(this);
+    Add(Metadata);
+
     Preview = new Preview(this);
+    Add(Preview);
+
+    RootDataset = new RootDataset(this);
+    Add(RootDataset);
   }
 
   /// <summary>

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -78,7 +78,7 @@ public class ROCrate
       else if (entityType == typeof(Metadata))
       {
         Metadata = entity as Metadata;
-        _dataEntities.Remove(entity as Metadata);
+        _dataEntities.Remove(Metadata);
         _dataEntities.Add(entity as Metadata);
         Entities.Remove(entity.Id);
       }
@@ -86,7 +86,7 @@ public class ROCrate
       else if (entityType == typeof(Preview))
       {
         Preview = entity as Preview;
-        _dataEntities.Remove(entity as Preview);
+        _dataEntities.Remove(Preview);
         _dataEntities.Add(entity as Preview);
         Entities.Remove(entity.Id);
       }

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -309,11 +309,20 @@ public class ROCrate
   /// The path to the directory containing the RO-Crate to initialise an <c>ROCrate</c> from.
   /// </param>
   /// <exception cref="CrateReadException">Thrown when there is an issue reading the RO-Crate.</exception>
+  /// <exception cref="MetadataException">Thrown when there is an issue with the RO-Crate's metadata.</exception>
   public void Initialise(string source)
   {
     try
     {
       CheckSourceMetadata(source);
+    }
+    catch (JsonException e)
+    {
+      throw new MetadataException("The RO-Crate metadata is invalid", e);
+    }
+    catch (InvalidDataException e)
+    {
+      throw new MetadataException("The RO-Crate metadata is invalid", e);
     }
     catch (Exception e)
     {

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -72,18 +72,23 @@ public class ROCrate
       if (entityType == typeof(RootDataset))
       {
         RootDataset = entity as RootDataset;
+        Entities.Remove(entity.Id);
       }
 
       else if (entityType == typeof(Metadata))
       {
         Metadata = entity as Metadata;
+        _dataEntities.Remove(entity as Metadata);
         _dataEntities.Add(entity as Metadata);
+        Entities.Remove(entity.Id);
       }
 
       else if (entityType == typeof(Preview))
       {
         Preview = entity as Preview;
+        _dataEntities.Remove(entity as Preview);
         _dataEntities.Add(entity as Preview);
+        Entities.Remove(entity.Id);
       }
 
       else if (entityType.IsSubclassOf(typeof(DataEntity)))

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO.Compression;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using ROCrates.Exceptions;
 using ROCrates.Models;
 using File = ROCrates.Models.File;
 
@@ -301,7 +302,36 @@ public class ROCrate
     Directory.Delete(saveLocation, recursive: true);
   }
 
+  /// <summary>
+  /// Initialise an <c>ROCrate</c> object from the contents of a directory that is a valid RO-Crate.
+  /// </summary>
+  /// <param name="source">
+  /// The path to the directory containing the RO-Crate to initialise an <c>ROCrate</c> from.
+  /// </param>
+  /// <exception cref="CrateReadException">Thrown when there is an issue reading the RO-Crate.</exception>
   public void Initialise(string source)
+  {
+    try
+    {
+      CheckSourceMetadata(source);
+    }
+    catch (Exception e)
+    {
+      throw new CrateReadException($"Could not read RO-Crate at {source}.", e);
+    }
+  }
+
+  /// <summary>
+  /// Check the metadata of an RO-Crate.
+  /// </summary>
+  /// <param name="source">
+  /// The path to the directory containing the RO-Crate to initialise an <c>ROCrate</c> from.
+  /// </param>
+  /// <exception cref="DirectoryNotFoundException">Can't find the source directory.</exception>
+  /// <exception cref="FileNotFoundException">Can't find the metadata JSON file.</exception>
+  /// <exception cref="JsonException">The metadata file is invalid JSON.</exception>
+  /// <exception cref="InvalidDataException">The metadata format is not satisfied.</exception>
+  private void CheckSourceMetadata(string source)
   {
     if (!Directory.Exists(source))
       throw new DirectoryNotFoundException($"{source} does not exist or is not a directory.");

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -421,6 +421,40 @@ public class ROCrate
   }
 
   /// <summary>
+  /// <para>Convert a directory into an RO-Crate.</para>
+  /// <para>
+  /// This method iterates over the files and directories contained inside <paramref name="source"/>
+  /// and populates an <c>ROCrate</c> object with entities representing the contents of the RO-Crate.
+  /// The <c>ro-crate-metadata.json</c> and <c>ro-crate-preview.html</c> files are then saved into
+  /// <paramref name="source"/>
+  /// </para>
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// var roCrate = new ROCrate();
+  /// roCrate.Convert("convertMe");
+  /// </code>
+  /// </example>
+  /// <param name="source">The path to the directory to be converted to an RO-Crate.</param>
+  public void Convert(string source)
+  {
+    var dirInfo = new DirectoryInfo(source);
+
+    foreach (var dir in dirInfo.EnumerateDirectories("*", SearchOption.AllDirectories))
+    {
+      var dataset = AddDataset(source: Path.GetRelativePath(dirInfo.FullName, dir.FullName));
+      foreach (var fileInfo in dir.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
+      {
+        var file = AddFile(source: fileInfo.Name);
+        dataset.AppendTo("hasPart", file);
+      }
+    }
+
+    Metadata.Write(source);
+    Preview.Write(source);
+  }
+
+  /// <summary>
   /// Check the metadata of an RO-Crate.
   /// </summary>
   /// <param name="source">

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -306,9 +306,27 @@ public class ROCrate
     if (!Directory.Exists(source))
       throw new DirectoryNotFoundException($"{source} does not exist or is not a directory.");
 
-    if (!System.IO.File.Exists(Path.Combine(source, "ro-crate-metadata.json")))
+    var metadataPath = Path.Combine(source, "ro-crate-metadata.json");
+    if (!System.IO.File.Exists(metadataPath))
       throw new FileNotFoundException(
         $@"Metadata file not found in {source}. If you would like this to be an RO-Crate, use Convert to convert it."
       );
+
+    var json = System.IO.File.ReadAllText(metadataPath);
+    JsonNode? metadataJson;
+    try
+    {
+      metadataJson = JsonNode.Parse(json);
+      if (metadataJson is null) throw new JsonException("Metadata file contains no metadata");
+    }
+    catch (JsonException)
+    {
+      throw new JsonException("Metadata file contains no metadata");
+    }
+
+    var metadataObject = metadataJson.AsObject();
+
+    if (!(metadataObject.ContainsKey("@context") || metadataObject.ContainsKey("@graph")))
+      throw new InvalidDataException("Metadata is missing @context, @graph or both.");
   }
 }


### PR DESCRIPTION
## Overview

- `ROCrate` objects can now be initialised from an existing crate using the `Initialise` method.
- A directory can be converted to an RO-Crate using the `Convert` method.
- Removed constructor with arguments from `ROCrate`.
- Fixed tests that depended on `ROCrate` constructor with arguments.

## Azure Boards

- AB#113765
- AB#113766
- AB#113769
- AB#113767
- AB#113770
- AB#113771
- AB#114150
