### PR TITLE
AB#109009: Unzip the wfexs execution crate into `Data/outputs/`

### DIFF
--- a/app/HutchAgent.Tests/TestCrateMergeService.cs
+++ b/app/HutchAgent.Tests/TestCrateMergeService.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using HutchAgent.Services;
 using ROCrates;
 using ROCrates.Models;
@@ -8,15 +9,22 @@ namespace HutchAgent.Tests;
 public class TestCrateMergeService
 {
   [Fact]
-  public void MergeCrates_Copies_ZipToDestination()
+  public void MergeCrates_Extract_ZipToDestinationDataOutputs()
   {
     // Arrange
     var destinationDir = new DirectoryInfo("save/here/");
     var zipFile = new FileInfo("test-zip.zip");
-    var expectedFile = new FileInfo(Path.Combine(destinationDir.ToString(), zipFile.Name));
-    File.Create(zipFile.Name).Close();
+    var metaFile = new FileInfo("ro-crate-metadata.json");
+    var expectedFile = new FileInfo(Path.Combine(destinationDir.ToString(), "Data", "outputs", metaFile.Name));
+    
     Directory.CreateDirectory(destinationDir.ToString());
+    File.Create(metaFile.Name).Close();
 
+    using (var zipArchive = ZipFile.Open(zipFile.ToString(), ZipArchiveMode.Create))
+    {
+        zipArchive.CreateEntryFromFile(metaFile.FullName, metaFile.Name);
+    }
+    
     var service = new CrateMergerService();
 
     // Act
@@ -27,6 +35,7 @@ public class TestCrateMergeService
 
     // Clean up
     if (zipFile.Exists) zipFile.Delete();
+    if (metaFile.Exists) metaFile.Delete();
     if (destinationDir.Exists) destinationDir.Parent!.Delete(true);
   }
 
@@ -39,7 +48,7 @@ public class TestCrateMergeService
     var expectedFile = new FileInfo($"save2/{destinationDir.Name}-merged.zip");
 
     Directory.CreateDirectory(destinationDir.ToString());
-    File.Create(zipFile.Name).Close();
+    File.Create(zipFile.ToString()).Close();
 
     var service = new CrateMergerService();
 

--- a/app/HutchAgent/Services/CrateMergerService.cs
+++ b/app/HutchAgent/Services/CrateMergerService.cs
@@ -9,7 +9,7 @@ namespace HutchAgent.Services;
 public class CrateMergerService
 {
   /// <summary>
-  /// Copy a source zipped RO-Crate into an unzipped destination RO-Crate and zip the
+  /// Extract a source zipped RO-Crate into an unzipped destination RO-Crate `Data/outputs` directory and zip the
   /// destination RO-Crate.
   /// </summary>
   /// <param name="sourceZip"></param>
@@ -28,12 +28,8 @@ public class CrateMergerService
     var outputs = Path.Combine(mergeInto, "Data", "outputs");
     Directory.CreateDirectory(outputs);
     
-    // Extract the result RO-Crate (`file`) into the unzipped original RO-Crate
+    // Extract the result (RO-Crate) into the unzipped original RO-Crate
     ZipFile.ExtractToDirectory(sourceZip, outputs);
-    
-    // Copy the result RO-Crate (`file`) into the unzipped original RO-Crate
-    // File.Copy(sourceZip, Path.Combine(outputs, Path.GetFileName(sourceZip)));
-
   }
 
   /// <summary>

--- a/app/HutchAgent/Services/CrateMergerService.cs
+++ b/app/HutchAgent/Services/CrateMergerService.cs
@@ -24,8 +24,16 @@ public class CrateMergerService
     var destinationInfo = new DirectoryInfo(mergeInto);
     if (!destinationInfo.Exists) throw new DirectoryNotFoundException($"{mergeInto} does not exist.");
 
+    // Create output directory `Data/outputs/` to extract execution crate
+    var outputs = Path.Combine(mergeInto, "Data", "outputs");
+    Directory.CreateDirectory(outputs);
+    
+    // Extract the result RO-Crate (`file`) into the unzipped original RO-Crate
+    ZipFile.ExtractToDirectory(sourceZip, outputs);
+    
     // Copy the result RO-Crate (`file`) into the unzipped original RO-Crate
-    File.Copy(sourceZip, Path.Combine(mergeInto, Path.GetFileName(sourceZip)));
+    // File.Copy(sourceZip, Path.Combine(outputs, Path.GetFileName(sourceZip)));
+
   }
 
   /// <summary>


### PR DESCRIPTION
## Overview

- Updated the existing **`MergeCrates`** service method which now extracts the zipped crate into the **`Data/outputs`** directory.
- Renamed existing **`MergeCrates_Copies_ZipToDestination`** test method of **`TestCrateMergeService`** to **`MergeCrates_Extract_ZipToDestinationDataOutputs`**.
- Updated the test method above, which now checks for the presence of the metadata file in the extracted folder.