### PR TITLE
AB#114638: Dataset @id not being set properly

### DIFF
--- a/lib/ROCrates.Net.Tests/TestDataset.cs
+++ b/lib/ROCrates.Net.Tests/TestDataset.cs
@@ -85,6 +85,36 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
     // Assert
     Assert.Equal(expectedJson, actualJson);
   }
+
+  [Fact]
+  public void DatasetIdTag_Is_UnixPath()
+  {
+    // Arrange
+
+    // Act
+
+    // Assert
+  }
+
+  [Fact]
+  public void DatasetIdTag_Ends_WithSlash()
+  {
+    // Arrange
+
+    // Act
+
+    // Assert
+  }
+
+  [Fact]
+  public void DatasetIdTag_Is_WholeSpecifiedPath()
+  {
+    // Arrange
+
+    // Act
+
+    // Assert
+  }
 }
 
 public class TestDatasetFixture : IDisposable

--- a/lib/ROCrates.Net.Tests/TestDataset.cs
+++ b/lib/ROCrates.Net.Tests/TestDataset.cs
@@ -93,32 +93,27 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
   {
     // Arrange
     var datasetSource = _testDatasetFixture.TestBasePath.Replace("/", "\\");
+    var expected = _testDatasetFixture.TestBasePath + '/';
 
     // Act
     var dataset = new Dataset(source: datasetSource);
 
     // Assert
-    Assert.Equal(_testDatasetFixture.TestBasePath + '/', dataset.Id);
+    Assert.Equal(expected, dataset.Id);
   }
 
   [Fact]
   public void DatasetIdTag_Ends_WithSlash()
   {
     // Arrange
+    var datasetSource = _testDatasetFixture.TestBasePath;
+    var expected = _testDatasetFixture.TestBasePath + '/';
 
     // Act
+    var dataset = new Dataset(source: datasetSource);
 
     // Assert
-  }
-
-  [Fact]
-  public void DatasetIdTag_Is_WholeSpecifiedPath()
-  {
-    // Arrange
-
-    // Act
-
-    // Assert
+    Assert.Equal(expected, dataset.Id);
   }
 }
 

--- a/lib/ROCrates.Net.Tests/TestDataset.cs
+++ b/lib/ROCrates.Net.Tests/TestDataset.cs
@@ -1,4 +1,6 @@
 using System.Text.Json.Nodes;
+using ROCrates.Models;
+using File = System.IO.File;
 
 namespace ROCrates.Tests;
 
@@ -90,10 +92,13 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
   public void DatasetIdTag_Is_UnixPath()
   {
     // Arrange
+    var datasetSource = _testDatasetFixture.TestBasePath.Replace("/", "\\");
 
     // Act
+    var dataset = new Dataset(source: datasetSource);
 
     // Assert
+    Assert.Equal(_testDatasetFixture.TestBasePath, dataset.Id);
   }
 
   [Fact]

--- a/lib/ROCrates.Net.Tests/TestDataset.cs
+++ b/lib/ROCrates.Net.Tests/TestDataset.cs
@@ -98,7 +98,7 @@ public class TestDataset : IClassFixture<TestDatasetFixture>
     var dataset = new Dataset(source: datasetSource);
 
     // Assert
-    Assert.Equal(_testDatasetFixture.TestBasePath, dataset.Id);
+    Assert.Equal(_testDatasetFixture.TestBasePath + '/', dataset.Id);
   }
 
   [Fact]

--- a/lib/ROCrates.Net.Tests/TestFileOrDir.cs
+++ b/lib/ROCrates.Net.Tests/TestFileOrDir.cs
@@ -44,8 +44,8 @@ public class TestFileOrDir
       fetchRemote: true);
 
     // Assert
-    Assert.Equal("my-file.txt", dataEntityWithLocal.Id);
-    Assert.Equal("my-file.txt", dataEntityWithRemote.Id);
+    Assert.Equal(localName, dataEntityWithLocal.Id);
+    Assert.Equal(remoteName, dataEntityWithRemote.Id);
   }
 
   [Fact]

--- a/lib/ROCrates.Net.Tests/TestFileOrDir.cs
+++ b/lib/ROCrates.Net.Tests/TestFileOrDir.cs
@@ -32,7 +32,7 @@ public class TestFileOrDir
   {
     // Arrange
     const string localName = "./path/to/my-file.txt";
-    const string remoteName = "ftp:///path/to/my-file.txt";
+    const string remoteName = "ftp:/some.host/path/to/my-file.txt";
 
     // Act
     var dataEntityWithLocal = new FileOrDir(

--- a/lib/ROCrates.Net/Models/Dataset.cs
+++ b/lib/ROCrates.Net/Models/Dataset.cs
@@ -105,10 +105,12 @@ public class Dataset : FileOrDir
 
   private protected sealed override string _formatIdentifier(string identifier)
   {
-    var newId = identifier.TrimEnd(Path.DirectorySeparatorChar);
-    newId = newId.TrimEnd(Path.AltDirectorySeparatorChar);
-    newId += "/";
-    return newId;
+    if (!identifier.EndsWith(Path.DirectorySeparatorChar) && !identifier.EndsWith(Path.AltDirectorySeparatorChar))
+    {
+      return identifier + Path.AltDirectorySeparatorChar;
+    }
+
+    return identifier;
   }
 
   /// <summary>

--- a/lib/ROCrates.Net/Models/FileOrDir.cs
+++ b/lib/ROCrates.Net/Models/FileOrDir.cs
@@ -31,7 +31,7 @@ public class FileOrDir : DataEntity
       }
 
       // Convert Windows paths to POSIX
-      Id = _destPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+      Id = _destPath.Replace('\\', Path.AltDirectorySeparatorChar);
     }
     // Source is remote
     else if (sourceUri.IsAbsoluteUri && !sourceUri.IsLoopback)

--- a/lib/ROCrates.Net/Models/FileOrDir.cs
+++ b/lib/ROCrates.Net/Models/FileOrDir.cs
@@ -34,7 +34,7 @@ public class FileOrDir : DataEntity
       Id = _destPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     }
     // Source is remote
-    else if (sourceUri.IsAbsoluteUri && sourceUri.Scheme != Uri.UriSchemeFile)
+    else if (sourceUri.IsAbsoluteUri && !sourceUri.IsLoopback)
     {
       Id = _source;
     }

--- a/lib/ROCrates.Net/Models/FileOrDir.cs
+++ b/lib/ROCrates.Net/Models/FileOrDir.cs
@@ -16,10 +16,12 @@ public class FileOrDir : DataEntity
     string? source = null,
     string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties)
   {
-    _source = source ?? "./";
+    _source = source ?? identifier ?? "./";
     _destPath = destPath;
     _fetchRemote = fetchRemote;
     _validateUrl = validateUrl;
+
+    var sourceUri = new Uri(_source, UriKind.RelativeOrAbsolute);
 
     if (_destPath != null)
     {
@@ -31,17 +33,15 @@ public class FileOrDir : DataEntity
       // Convert Windows paths to POSIX
       Id = _destPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     }
-    else if (Uri.IsWellFormedUriString(_source, UriKind.RelativeOrAbsolute) && _fetchRemote)
+    // Source is remote
+    else if (sourceUri.IsAbsoluteUri && sourceUri.Scheme != Uri.UriSchemeFile)
     {
-      Id = Path.GetFileName(_source);
-    }
-    else if (Path.GetFileName(_source) != String.Empty)
-    {
-      Id = Path.GetFileName(_source);
+      Id = _source;
     }
     else
     {
-      Id = _source;
+      // Convert Windows paths to POSIX
+      Id = _source.Replace('\\', Path.AltDirectorySeparatorChar);
     }
   }
 


### PR DESCRIPTION
## Overview

Make sure `@id` tags for dataset comes out as the given path (relative to the create root) with a slash (`/`) at the end.

## Azure Boards

- AB#114640
- AB#114641
- AB#114642
