### PR TITLE
AB#114963: ROCrate.Convert must make all file and directory `@id`s relative to crate root

### DIFF
--- a/lib/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/lib/ROCrates.Net.Tests/TestRoCrate.cs
@@ -306,12 +306,16 @@ public class TestRoCrate
     roCrate.Convert(testDir.FullName);
 
     // Assert
-    Assert.Contains(topLevelFile.Name, roCrate.Entities.Keys);
     Assert.Contains(
-      Path.GetRelativePath(
-        testDir.FullName,
-        subDir.FullName
-      ) + "/",
+      Path.GetRelativePath(testDir.FullName, topLevelFile.FullName),
+      roCrate.Entities.Keys
+    );
+    Assert.Contains(
+      Path.GetRelativePath(testDir.FullName, subDir.FullName) + "/",
+      roCrate.Entities.Keys
+    );
+    Assert.Contains(
+      Path.GetRelativePath(testDir.FullName, subDirFile.FullName),
       roCrate.Entities.Keys
     );
 

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -449,7 +449,7 @@ public class ROCrate
       var dataset = AddDataset(source: Path.GetRelativePath(dirInfo.FullName, dir.FullName));
       foreach (var fileInfo in dir.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
       {
-        var file = AddFile(source: fileInfo.Name);
+        var file = AddFile(source: Path.GetRelativePath(dirInfo.FullName, fileInfo.FullName));
         dataset.AppendTo("hasPart", file);
       }
     }
@@ -457,7 +457,7 @@ public class ROCrate
     // Add files in the top level of `source`
     foreach (var f in dirInfo.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
     {
-      AddFile(source: f.Name);
+      AddFile(source: Path.GetRelativePath(dirInfo.FullName, f.FullName));
     }
 
     Metadata.Write(source);

--- a/lib/ROCrates.Net/ROCrate.cs
+++ b/lib/ROCrates.Net/ROCrate.cs
@@ -441,23 +441,23 @@ public class ROCrate
   /// <param name="source">The path to the directory to be converted to an RO-Crate.</param>
   public void Convert(string source)
   {
-    var dirInfo = new DirectoryInfo(source);
+    var rootDir = new DirectoryInfo(source);
 
     // Add directories and files contained in those directories
-    foreach (var dir in dirInfo.EnumerateDirectories("*", SearchOption.AllDirectories))
+    foreach (var dir in rootDir.EnumerateDirectories("*", SearchOption.AllDirectories))
     {
-      var dataset = AddDataset(source: Path.GetRelativePath(dirInfo.FullName, dir.FullName));
+      var dataset = AddDataset(source: Path.GetRelativePath(rootDir.FullName, dir.FullName));
       foreach (var fileInfo in dir.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
       {
-        var file = AddFile(source: Path.GetRelativePath(dirInfo.FullName, fileInfo.FullName));
+        var file = AddFile(source: Path.GetRelativePath(rootDir.FullName, fileInfo.FullName));
         dataset.AppendTo("hasPart", file);
       }
     }
 
     // Add files in the top level of `source`
-    foreach (var f in dirInfo.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
+    foreach (var f in rootDir.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
     {
-      AddFile(source: Path.GetRelativePath(dirInfo.FullName, f.FullName));
+      AddFile(source: Path.GetRelativePath(rootDir.FullName, f.FullName));
     }
 
     Metadata.Write(source);


### PR DESCRIPTION
## Overview

`ROCrate.Convert` now makes all `@id` tags relative to the crate root. So `path/to/file.txt` will have an `@id` of `path/to/file.txt`, where previously it was just `file.txt`.

## Azure Boards

- AB#114964
- AB#114965
- AB#114966
