### PR TITLE
AB#115971: Update the Pid property when updating a Wfexs job and include the Pid property in the jobs list

### DIFF
--- a/app/HutchAgent/Services/WfexsJobService.cs
+++ b/app/HutchAgent/Services/WfexsJobService.cs
@@ -48,7 +48,8 @@ public class WfexsJobService
           Id = x.Id,
           UnpackedPath = x.UnpackedPath,
           WfexsRunId = x.WfexsRunId,
-          RunFinished = x.RunFinished
+          RunFinished = x.RunFinished,
+          Pid = x.Pid
         }
       ).ToListAsync();
     return list;
@@ -79,6 +80,7 @@ public class WfexsJobService
   public async Task<WfexsJob> Set(WfexsJob job)
   {
     var entity = await _db.WfexsJobs.FindAsync(job.Id) ?? throw new KeyNotFoundException();
+    entity.Pid = job.Pid;
     entity.UnpackedPath = job.UnpackedPath;
     entity.WfexsRunId = job.WfexsRunId;
     entity.RunFinished = job.RunFinished;


### PR DESCRIPTION
## Overview

- A Wfexs job **`Pid`** will be updated when updating the passed the job.

- List of Wfexs jobs will now include job **`Pid`** property, which polling service can use to check the process status and update the job **`RunFinished`** property.

## Azure Boards

- AB#115972
- AB#115973
- AB#115974