### PR TITLE
AB#108987: Add publisher and datePublished to the root data entity

### DIFF
--- a/app/HutchAgent.Tests/TestCrateMergeService.cs
+++ b/app/HutchAgent.Tests/TestCrateMergeService.cs
@@ -1,5 +1,7 @@
 using System.IO.Compression;
+using HutchAgent.Config;
 using HutchAgent.Services;
+using Microsoft.Extensions.Options;
 using ROCrates;
 using ROCrates.Models;
 using File = System.IO.File;
@@ -12,6 +14,7 @@ public class TestCrateMergeService
   public void MergeCrates_Extract_ZipToDestinationDataOutputs()
   {
     // Arrange
+    var publisher = Options.Create(new PublisherOptions(){ Name = "TRE name" });
     var pathToOutputDir = Path.Combine("data", "outputs");
     var destinationDir = new DirectoryInfo("save/here/");
     var zipFile = new FileInfo("test-zip.zip");
@@ -26,7 +29,7 @@ public class TestCrateMergeService
         zipArchive.CreateEntryFromFile(metaFile.FullName, metaFile.Name);
     }
     
-    var service = new CrateMergerService();
+    var service = new CrateMergerService(publisher);
 
     // Act
     service.MergeCrates(zipFile.Name, destinationDir.ToString());
@@ -44,6 +47,7 @@ public class TestCrateMergeService
   public void ZipCrate_Zips_DestinationToParent()
   {
     // Arrange
+    var publisher = Options.Create(new PublisherOptions(){ Name = "TRE name" });
     var destinationDir = new DirectoryInfo("save2/here/");
     var zipFile = new FileInfo(Path.Combine(destinationDir.ToString(), "test-zip.zip"));
     var expectedFile = new FileInfo($"save2/{destinationDir.Name}-merged.zip");
@@ -51,7 +55,7 @@ public class TestCrateMergeService
     Directory.CreateDirectory(destinationDir.ToString());
     File.Create(zipFile.ToString()).Close();
 
-    var service = new CrateMergerService();
+    var service = new CrateMergerService(publisher);
 
     // Act
     service.ZipCrate(destinationDir.ToString());
@@ -68,10 +72,11 @@ public class TestCrateMergeService
   public void MergeCrates_Throws_WhenDestinationNonExistent()
   {
     // Arrange
+    var publisher = Options.Create(new PublisherOptions(){ Name = "TRE name" });
     var zipFileName = "my-file.zip";
     var destinationDir = "non/existent/dir/";
     Directory.CreateDirectory("non/existent/");
-    var service = new CrateMergerService();
+    var service = new CrateMergerService(publisher);
 
     // Act
     var action = () => service.MergeCrates(zipFileName, destinationDir);
@@ -87,8 +92,9 @@ public class TestCrateMergeService
   public void ZipCrate_Throws_WhenDestinationNonExistent()
   {
     // Arrange
+    var publisher = Options.Create(new PublisherOptions(){ Name = "TRE name" });
     var destinationDir = "non/existent/dir/";
-    var service = new CrateMergerService();
+    var service = new CrateMergerService(publisher);
 
     // Act
     var action = () => service.ZipCrate(destinationDir);
@@ -101,8 +107,9 @@ public class TestCrateMergeService
   public void UpdateMetadata_Throws_WhenSourceNonExistent()
   {
     // Arrange
+    var publisher = Options.Create(new PublisherOptions(){ Name = "TRE name" });
     var pathToMetadata = "non/existent/ro-crate-metadata.json";
-    var service = new CrateMergerService();
+    var service = new CrateMergerService(publisher);
 
     // Act
     var action = () => service.UpdateMetadata(pathToMetadata);
@@ -115,6 +122,7 @@ public class TestCrateMergeService
   public void UpdateMetadata_Adds_MergedEntity()
   {
     // Arrange
+    var publisher = Options.Create(new PublisherOptions(){ Name = "TRE name" });
     var pathToOutputDir = Path.Combine("data", "outputs");
     var crate = new ROCrate();
     var rootDataset = new RootDataset(crate: crate);
@@ -134,7 +142,7 @@ public class TestCrateMergeService
     var folderObject = new Dataset(crate: crate, source: folderToAdd);
     crate.Add(folderObject);
 
-    var service = new CrateMergerService();
+    var service = new CrateMergerService(publisher);
 
     // Act
     service.UpdateMetadata(crate.Metadata.Id);

--- a/app/HutchAgent.Tests/TestCrateMergeService.cs
+++ b/app/HutchAgent.Tests/TestCrateMergeService.cs
@@ -166,6 +166,6 @@ public class TestCrateMergeService
     
     // Clean up
     if (File.Exists(crate.Metadata.Id)) File.Delete(crate.Metadata.Id);
-    if (Directory.Exists(outputDirToAdd)) Directory.Delete((outputDirToAdd));
+    if (Directory.Exists(outputDirToAdd)) Directory.Delete(outputDirToAdd, recursive: true);
   }
 }

--- a/app/HutchAgent.Tests/TestCrateMergeService.cs
+++ b/app/HutchAgent.Tests/TestCrateMergeService.cs
@@ -142,11 +142,6 @@ public class TestCrateMergeService
     var outputDirToAdd = Path.Combine(metaFile.DirectoryName, pathToOutputDir);
     Directory.CreateDirectory(outputDirToAdd);
     
-    var service = new CrateMergerService(publisher);
-
-    // Act
-    service.UpdateMetadata(metaFile.DirectoryName);
-    var output = File.ReadAllText(crate.Metadata.Id);
     var pattern1 = "\"@id\": " 
                    + "\""
                    + $"{Path.GetRelativePath(metaFile.DirectoryName, Path.Combine(metaFile.DirectoryName, pathToOutputDir))}/" 
@@ -157,6 +152,13 @@ public class TestCrateMergeService
                    + $"{publisher.Value.Name}" 
                    + "\"";
     var pattern4 = "\"datePublished\": ";
+    
+    var service = new CrateMergerService(publisher);
+
+    // Act
+    service.UpdateMetadata(metaFile.DirectoryName);
+    var output = File.ReadAllText(crate.Metadata.Id);
+
     
     // Assert
     Assert.Contains(pattern1, output);

--- a/app/HutchAgent/Config/PublisherOptions.cs
+++ b/app/HutchAgent/Config/PublisherOptions.cs
@@ -1,0 +1,6 @@
+namespace HutchAgent.Config;
+
+public class PublisherOptions
+{
+  public string Name { get; set; } = string.Empty;
+}

--- a/app/HutchAgent/HostedServices/JobPollingHostedService.cs
+++ b/app/HutchAgent/HostedServices/JobPollingHostedService.cs
@@ -65,6 +65,7 @@ public class JobPollingHostedService : BackgroundService
 
   private async Task UploadResults()
   {
+    if (_wfexsJobService is null) throw new NullReferenceException("_wfexsJobService instance not available");
     var finishedJobs = await _wfexsJobService.ListFinishedJobs();
     foreach (var job in finishedJobs)
     {
@@ -83,6 +84,7 @@ public class JobPollingHostedService : BackgroundService
           job.WfexsRunId)
       );
 
+      if (_resultsStoreWriter is null) throw new NullReferenceException("_resultsStoreWriter instance not available");
       if (await _resultsStoreWriter.ResultExists(pathToUploadInfo.Name))
       {
         _logger.LogInformation($"{pathToUploadInfo.Name} already exists in S3.");
@@ -108,6 +110,7 @@ public class JobPollingHostedService : BackgroundService
 
   private async Task MergeResults()
   {
+    if (_wfexsJobService is null) throw new NullReferenceException("_wfexsJobService instance not available");
     var finishedJobs = await _wfexsJobService.ListFinishedJobs();
     foreach (var job in finishedJobs)
     {
@@ -128,11 +131,13 @@ public class JobPollingHostedService : BackgroundService
         continue;
       }
 
+      if (_crateMergerService is null) throw new NullReferenceException("_crateMergerService instance not available");
       _crateMergerService.MergeCrates(sourceZip, job.UnpackedPath);
       _crateMergerService.DeleteContainerImages(pathToContainerImagesDir);
       _crateMergerService.UpdateMetadata(pathToMetadata);
       _crateMergerService.ZipCrate(job.UnpackedPath);
 
+      if (_resultsStoreWriter is null) throw new NullReferenceException("_resultsStoreWriter instance not available");
       if (await _resultsStoreWriter.ResultExists(mergedZip))
       {
         _logger.LogInformation($"Merged Crate {mergedZip} already exists in results store.");
@@ -149,6 +154,7 @@ public class JobPollingHostedService : BackgroundService
   /// </summary>
   private async Task CheckJobsFinished()
   {
+    if (_wfexsJobService is null) throw new NullReferenceException("_wfexsJobService instance not available");
     var unfinishedJobs = await _wfexsJobService.List();
     unfinishedJobs = unfinishedJobs.FindAll(x => !x.RunFinished);
 

--- a/app/HutchAgent/HostedServices/JobPollingHostedService.cs
+++ b/app/HutchAgent/HostedServices/JobPollingHostedService.cs
@@ -116,7 +116,7 @@ public class JobPollingHostedService : BackgroundService
         "wfexs-backend-test_WorkDir",
         job.WfexsRunId);
       var sourceZip = Path.Combine(jobWorkDir, "outputs", $"{job.WfexsRunId}.zip");
-      var pathToMetadata = Path.Combine(job.UnpackedPath, "ro-crate-metadata.json");
+      var pathToMetadata = Path.Combine(job.UnpackedPath); // directory path to ro-crate-metadata.json
       var mergeDirInfo = new DirectoryInfo(job.UnpackedPath);
       var mergeDirParent = mergeDirInfo.Parent;
       var mergedZip = Path.Combine(mergeDirParent!.FullName, $"{mergeDirInfo.Name}-merged.zip");

--- a/app/HutchAgent/Program.cs
+++ b/app/HutchAgent/Program.cs
@@ -25,6 +25,7 @@ builder.Services
   .Configure<MinioOptions>(builder.Configuration.GetSection("MinIO"))
   .Configure<JobPollingOptions>(builder.Configuration.GetSection("WatchFolder"))
   .Configure<WorkflowTriggerOptions>(builder.Configuration.GetSection("Wfexs"))
+  .Configure<PublisherOptions>(builder.Configuration.GetSection("Publisher"))
   .AddScoped<WorkflowTriggerService>()
   .AddResultsStore(builder.Configuration)
   .AddTransient<WfexsJobService>()

--- a/app/HutchAgent/Services/CrateMergerService.cs
+++ b/app/HutchAgent/Services/CrateMergerService.cs
@@ -86,8 +86,6 @@ public class CrateMergerService
     {
       Id = _publisherOptions.Name
     });
-    crate.Save(location:metaDirInfo.FullName);
-    
     crate.RootDataset.SetProperty("datePublished",DateTime.Now.ToString("yyyy-MM-dd'T'HH:mm:ssK"));
     crate.Save(location:metaDirInfo.FullName);
   }

--- a/app/HutchAgent/Services/CrateMergerService.cs
+++ b/app/HutchAgent/Services/CrateMergerService.cs
@@ -1,5 +1,9 @@
 using System.IO.Compression;
-using System.Text.Json.Nodes;
+using HutchAgent.Config;
+using Microsoft.Extensions.Options;
+using ROCrates;
+using ROCrates.Models;
+using File = System.IO.File;
 
 namespace HutchAgent.Services;
 
@@ -9,6 +13,11 @@ namespace HutchAgent.Services;
 public class CrateMergerService
 {
   private readonly string _pathToOutputDir = Path.Combine("data","outputs");
+  private readonly PublisherOptions _publisherOptions;
+  public CrateMergerService(IOptions<PublisherOptions> publisher)
+  {
+    _publisherOptions = publisher.Value;
+  }
   /// <summary>
   /// Extract a source zipped RO-Crate into an unzipped destination RO-Crate `Data/outputs` directory and zip the
   /// destination RO-Crate.
@@ -60,28 +69,27 @@ public class CrateMergerService
   /// <exception cref="InvalidDataException">The metadata file is invalid.</exception>
   public void UpdateMetadata(string pathToMetadata)
   {
-    if (!File.Exists(pathToMetadata))
+    if (!File.Exists(Path.Combine(pathToMetadata, "ro-crate-metadata.json")))
       throw new FileNotFoundException("Could not locate the metadata for the RO-Crate.");
-
-    var rootDirInfo = new DirectoryInfo(pathToMetadata).Parent; // get root dir info
     
-    var folderToAdd = Path.Combine(rootDirInfo.FullName, _pathToOutputDir);
+    var metaDirInfo = new DirectoryInfo(pathToMetadata);
     
-    if (!Directory.Exists(folderToAdd))
+    var outputsDirToAdd = Path.Combine(metaDirInfo.FullName, _pathToOutputDir);
+    if (!Directory.Exists(outputsDirToAdd))
       throw new DirectoryNotFoundException("Could not locate the folder to add to the metadata.");
+    var outputs = new Dataset(source: Path.GetRelativePath(metaDirInfo.FullName, outputsDirToAdd));
     
-    var metadataJson = File.ReadAllText(pathToMetadata);
-    var metadata = JsonNode.Parse(metadataJson);
-    if (metadata is null) throw new InvalidDataException($"{pathToMetadata} is not a valid JSON file.");
-
-    if (!metadata.AsObject().TryGetPropertyValue("@graph", out var graph))
-      throw new InvalidDataException("Cannot find entities in the RO-Crate metadata.");
-
-    var rootDatasetProperties = graph.AsArray().First(g => g["@id"].ToString() == "./");
-    var folder = new ROCrates.Models.Dataset(source: Path.GetRelativePath(rootDirInfo.FullName, folderToAdd)).Serialize();
-    rootDatasetProperties["hasPart"].AsArray().Add(JsonNode.Parse(folder));
-
-    File.WriteAllText(pathToMetadata, metadata.ToString());
+    var crate = new ROCrate();
+    crate.Initialise(metaDirInfo.FullName);
+    crate.RootDataset.AppendTo("hasPart",outputs);
+    crate.RootDataset.SetProperty("publisher", new Part()
+    {
+      Id = _publisherOptions.Name
+    });
+    crate.Save(location:metaDirInfo.FullName);
+    
+    crate.RootDataset.SetProperty("datePublished",DateTime.Now.ToString("yyyy-MM-dd'T'HH:mm:ssK"));
+    crate.Save(location:metaDirInfo.FullName);
   }
   
   /// <summary>


### PR DESCRIPTION
## Overview

- Updated the **`UpdateMetadata`** method of **`CrateMergerService`** which now:
  - adds **`publisher`** property based on publisher config to the root data entity
  - adds **`publishedDate`** after the final metadata update
- Updated relevant test methods.

## Azure Boards

- AB#109781
- AB#109790
- AB#116730

## Notes

_**`_pathToOutputDir`** in **`CrateMergerService`** might need to be updated in the future._
