### PR TITLE
AB#123923: Ansible for podman

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -8,6 +8,9 @@
 - name: Install Docker and Docker Compose
   ansible.builtin.import_playbook: playbooks/install-docker.yml
 
+- name: Install Podman
+  ansible.builtin.import_playbook: playbooks/install-podman.yml
+
 - name: Install WfExS
   ansible.builtin.import_playbook: playbooks/wfexs.yml
 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -17,7 +17,7 @@
     - name: Clone HUTCH
       ansible.builtin.git:
         repo: https://github.com/HDRUK/hutch
-        dest: $HOME/hutch
+        dest: "{{ ansible_env.HOME }}/hutch"
         version: main
 
 - name: Run Nexus, MinIO, Postgres, etc.
@@ -25,7 +25,7 @@
   tasks:
     - name: Run Docker Compose
       community.docker.docker_compose:
-        project_src: $HOME/hutch
+        project_src: "{{ ansible_env.HOME }}/hutch"
         project_name: hutch
         files:
           - docker-compose.yml

--- a/ansible/playbooks/files/install-podman4.sh
+++ b/ansible/playbooks/files/install-podman4.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/env bash
+
 mkdir -p /etc/apt/keyrings
 curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
   | gpg --dearmor \

--- a/ansible/playbooks/files/install-podman4.sh
+++ b/ansible/playbooks/files/install-podman4.sh
@@ -1,0 +1,10 @@
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
+  | gpg --dearmor \
+  | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
+    https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
+  | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
+sudo apt-get update -qq
+sudo apt-get -qq -y install podman

--- a/ansible/playbooks/files/install-podman4.sh
+++ b/ansible/playbooks/files/install-podman4.sh
@@ -1,10 +1,10 @@
-sudo mkdir -p /etc/apt/keyrings
+mkdir -p /etc/apt/keyrings
 curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
   | gpg --dearmor \
-  | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+  | tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
     https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
-  | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
-sudo apt-get update -qq
-sudo apt-get -qq -y install podman
+  | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
+apt-get update -qq
+apt-get -qq -y install podman

--- a/ansible/playbooks/install-docker.yml
+++ b/ansible/playbooks/install-docker.yml
@@ -1,6 +1,9 @@
 ---
 - name: Install Docker
   hosts: tre_server
+  handlers:
+    - name: Reset connnection
+      ansible.builtin.meta: reset_connection
   tasks:
     - name: Install Docker pre-requisites
       become: true
@@ -28,6 +31,17 @@
       ansible.builtin.apt:
         name: docker-ce
         update_cache: true
+
+    - name: Add user to docker group
+      become: true
+      ansible.builtin.user:
+        name: "{{ ansible_user }}"
+        append: true
+        groups:
+          - docker
+      register: user_added_to_docker
+      notify:
+        - Reset connnection
 
     - name: Install docker-compose
       become: true

--- a/ansible/playbooks/install-podman.yml
+++ b/ansible/playbooks/install-podman.yml
@@ -1,20 +1,23 @@
 ---
-- name: Upload podman script
-  ansible.builtin.copy:
-    src: files/install-podman4.sh
-    dest: "{{ ansible_env.HOME }}/install-podman4.sh"
-    mode: "0777"
+- name: Install and set up Podman
+  hosts: tre_server
+  tasks:
+    - name: Upload podman script
+      ansible.builtin.copy:
+        src: files/install-podman4.sh
+        dest: "{{ ansible_env.HOME }}/install-podman4.sh"
+        mode: "0777"
 
-- name: Install Podman
-  become: true
-  ansible.builtin.command:
-    cmd: ./install-podman4.sh
+    - name: Install Podman
+      become: true
+      ansible.builtin.command:
+        cmd: ./install-podman4.sh
 
-- name: Add registries.conf
-  become: true
-  ansible.builtin.copy:
-    src: files/registries.conf
-    dest: /etc/containers/registries.conf
-    owner: root
-    group: root
-    mode: "0644"
+    - name: Add registries.conf
+      become: true
+      ansible.builtin.copy:
+        src: files/registries.conf
+        dest: /etc/containers/registries.conf
+        owner: root
+        group: root
+        mode: "0644"

--- a/ansible/playbooks/install-podman.yml
+++ b/ansible/playbooks/install-podman.yml
@@ -1,0 +1,20 @@
+---
+- name: Upload podman script
+  ansible.builtin.copy:
+    src: files/install-podman4.sh
+    dest: "{{ ansible_env.HOME }}/install-podman4.sh"
+    mode: "0777"
+
+- name: Install Podman
+  become: true
+  ansible.builtin.command:
+    cmd: ./install-podman4.sh
+
+- name: Add registries.conf
+  become: true
+  ansible.builtin.copy:
+    src: files/registries.conf
+    dest: /etc/containers/registries.conf
+    owner: root
+    group: root
+    mode: "0644"

--- a/ansible/playbooks/set-up-ssl.yml
+++ b/ansible/playbooks/set-up-ssl.yml
@@ -3,34 +3,31 @@
   hosts: tre_server
   tasks:
     - name: Generate an private key
-      become: true
       community.crypto.openssl_privatekey:
-        path: $HOME/key.pem
+        path: "{{ ansible_env.HOME }}/key.pem"
 
     - name: Generate certificate signing request
-      become: true
       community.crypto.openssl_csr:
-        path: $HOME/crt.csr
-        privatekey_path: $HOME/key.pem
+        path: "{{ ansible_env.HOME }}/crt.csr"
+        privatekey_path: "{{ ansible_env.HOME }}/key.pem"
         common_name: workflowhub.eu
 
     - name: Generate self-signed certificate
-      become: true
       community.crypto.x509_certificate:
-        path: $HOME/cert.crt
-        privatekey_path: $HOME/key.pem
-        csr_path: $HOME/crt.csr
+        path: "{{ ansible_env.HOME }}/cert.crt"
+        privatekey_path: "{{ ansible_env.HOME }}/key.pem"
+        csr_path: "{{ ansible_env.HOME }}/crt.csr"
         provider: selfsigned
 
     - name: Copy cert.crt to trust store
       become: true
       ansible.builtin.copy:
-        src: $HOME/cert.crt
+        src: "{{ ansible_env.HOME }}/cert.crt"
         dest: /usr/share/ca-certificates/cert.crt
         remote_src: true
         owner: root
         group: root
-        mode: '0644'
+        mode: "0644"
 
     - name: Add cert.crt to /etc/ca-certificates.conf
       become: true
@@ -39,5 +36,6 @@
         line: cert.crt
 
     - name: Update CA certificates
+      become: true
       ansible.builtin.command:
         cmd: update-ca-certificates

--- a/ansible/playbooks/set-up-vm.yml
+++ b/ansible/playbooks/set-up-vm.yml
@@ -27,7 +27,7 @@
     - name: Add nginx.conf
       ansible.builtin.copy:
         src: files/nginx.conf
-        dest: $HOME/nginx.conf
+        dest: "{{ ansible_env.HOME }}/nginx.conf"
         mode: "0644"
 
     - name: Make workflowhub.eu traffic redirect to localhost

--- a/ansible/playbooks/set-up-vm.yml
+++ b/ansible/playbooks/set-up-vm.yml
@@ -31,6 +31,7 @@
         mode: "0644"
 
     - name: Make workflowhub.eu traffic redirect to localhost
+      become: true
       ansible.builtin.lineinfile:
         path: /etc/hosts
         line: 127.0.0.1 workflowhub.eu

--- a/ansible/playbooks/set-up-vm.yml
+++ b/ansible/playbooks/set-up-vm.yml
@@ -24,21 +24,6 @@
           - dotnet-sdk-6.0
           - aspnetcore-runtime-6.0
 
-    - name: Install podman
-      become: true
-      ansible.builtin.apt:
-        name:
-          - podman
-
-    - name: Add registries.conf
-      become: true
-      ansible.builtin.copy:
-        src: files/registries.conf
-        dest: /etc/containers/registries.conf
-        owner: root
-        group: root
-        mode: "0644"
-
     - name: Add nginx.conf
       ansible.builtin.copy:
         src: files/nginx.conf

--- a/ansible/playbooks/wfexs.yml
+++ b/ansible/playbooks/wfexs.yml
@@ -5,16 +5,16 @@
     - name: Clone WfExS
       ansible.builtin.git:
         repo: https://github.com/dcl10/WfExS-backend.git
-        dest: $HOME/WfExS-backend
+        dest: "{{ ansible_env.HOME }}/WfExS-backend"
         version: "main"
 
     - name: WfExS virtual enviroment
       ansible.builtin.command:
         cmd: python3 -m venv .pyWEenv
-        chdir: $HOME/WfExS-backend
-        creates: $HOME/WfExS-backend/.pyWEenv
+        chdir: "{{ ansible_env.HOME }}/WfExS-backend"
+        creates: "{{ ansible_env.HOME }}/WfExS-backend/.pyWEenv"
 
     - name: Install WfExS basic requirements
       ansible.builtin.command:
         cmd: ./full-installer.bash
-        chdir: $HOME/WfExS-backend
+        chdir: "{{ ansible_env.HOME }}/WfExS-backend"


### PR DESCRIPTION
## Overview

Added ansible playbook for installing podman 4.x rather than the default 3.x on Ubuntu.
Added fixes for:
- Making sure non root user can run docker
- Not using root where unnecessary
- Using ansible's magic variables for the remote user home and username

## Azure Boards

- AB#124118
- AB#124119
- AB#124120
- AB#124121
