### PR TITLE
AB#124761: Refactor post execution checks

### DIFF
--- a/app/HutchAgent.Tests/TestCrateService.cs
+++ b/app/HutchAgent.Tests/TestCrateService.cs
@@ -14,10 +14,11 @@ namespace HutchAgent.Tests;
 public class TestCrateService
 {
   private readonly IOptions<PathOptions> _paths;
-  
+
   public TestCrateService()
   {
-    _paths = Options.Create<PathOptions>(new(){
+    _paths = Options.Create<PathOptions>(new()
+    {
       // TODO
     });
   }
@@ -128,7 +129,7 @@ public class TestCrateService
     var pathToMetadata = "non/existent/ro-crate-metadata.json";
     var startTime = DateTime.Now;
     var endTime = startTime + TimeSpan.FromMinutes(2);
-    var job = new HutchAgent.Data.Entities.WorkflowJob { ExecutionStartTime = startTime, EndTime = endTime };
+    var job = new Models.WorkflowJob { ExecutionStartTime = startTime, EndTime = endTime };
     var service = new CrateService(_paths, publisher, logger.Object);
 
     // Act
@@ -176,7 +177,7 @@ public class TestCrateService
     var service = new CrateService(_paths, publisher, logger.Object);
     var startTime = DateTime.Now;
     var endTime = startTime + TimeSpan.FromMinutes(2);
-    var job = new Data.Entities.WorkflowJob { ExecutionStartTime = startTime, EndTime = endTime };
+    var job = new Models.WorkflowJob { ExecutionStartTime = startTime, EndTime = endTime };
     // Act
     service.UpdateMetadata(metaFile.DirectoryName, job);
     var output = File.ReadAllText(crate.Metadata.Id);

--- a/app/HutchAgent/Program.cs
+++ b/app/HutchAgent/Program.cs
@@ -26,25 +26,22 @@ builder.Services.AddDbContext<HutchAgentContext>(o =>
 // All other services
 builder.Services
   .Configure<PathOptions>(builder.Configuration.GetSection("Paths"))
-
   .Configure<RabbitQueueOptions>(builder.Configuration.GetSection("Queue"))
   .Configure<JobActionsQueueOptions>(builder.Configuration.GetSection("Queue"))
-
   .Configure<MinioOptions>(builder.Configuration.GetSection("MinIO"))
   .Configure<WorkflowTriggerOptions>(builder.Configuration.GetSection("Wfexs"))
   .Configure<PublisherOptions>(builder.Configuration.GetSection("Publisher"))
-
   .AddScoped<WorkflowTriggerService>()
   .AddResultsStore(builder.Configuration)
   .AddTransient<WorkflowJobService>()
   .AddHostedService<QueuePollingHostedService>()
-
   .AddTransient<CrateService>()
   .AddSingleton<BagItService>()
   .AddTransient<IQueueWriter, RabbitQueueWriter>()
   .AddTransient<IQueueReader, RabbitQueueReader>()
-
+  .AddSingleton<FinalisationService>()
   .AddFeatureManagement();
+
 #endregion
 
 var app = builder.Build();

--- a/app/HutchAgent/Program.cs
+++ b/app/HutchAgent/Program.cs
@@ -39,7 +39,7 @@ builder.Services
   .AddSingleton<BagItService>()
   .AddTransient<IQueueWriter, RabbitQueueWriter>()
   .AddTransient<IQueueReader, RabbitQueueReader>()
-  .AddSingleton<FinalisationService>()
+  .AddScoped<FinalisationService>()
   .AddFeatureManagement();
 
 #endregion

--- a/app/HutchAgent/Services/CrateService.cs
+++ b/app/HutchAgent/Services/CrateService.cs
@@ -3,7 +3,6 @@ using System.IO.Compression;
 using System.Text.Json.Nodes;
 using HutchAgent.Config;
 using HutchAgent.Constants;
-using HutchAgent.Data.Entities;
 using Microsoft.Extensions.Options;
 using ROCrates;
 using ROCrates.Exceptions;
@@ -82,11 +81,6 @@ public class CrateService
   }
 
 
-
-
-
-
-
   /// <summary>
   /// Extract a source zipped RO-Crate into an unzipped destination RO-Crate `Data/outputs` directory and zip the
   /// destination RO-Crate.
@@ -128,7 +122,6 @@ public class CrateService
     ZipFile.CreateFromDirectory(cratePath, Path.Combine(parent!.ToString(), zipFile));
   }
 
-  
 
   /// <summary>
   /// Update the target metadata file in an RO-Crate.
@@ -139,7 +132,7 @@ public class CrateService
   /// Metadata file could not be found.
   /// </exception>
   /// <exception cref="InvalidDataException">The metadata file is invalid.</exception>
-  public void UpdateMetadata(string pathToMetadata, WorkflowJob job)
+  public void UpdateMetadata(string pathToMetadata, Models.WorkflowJob job)
   {
     if (!File.Exists(Path.Combine(pathToMetadata, "ro-crate-metadata.json")))
       throw new FileNotFoundException("Could not locate the metadata for the RO-Crate.");
@@ -239,40 +232,40 @@ public class CrateService
     switch (actionType)
     {
       case ActionType.CheckValueType:
-        {
-          assessActions = assessActions.Where(mention =>
-            roCrate.Entities[mention!["@id"]!.ToString()].Properties["additionalType"]?["@id"]?.ToString() ==
-            ActionType.CheckValueType);
-          break;
-        }
+      {
+        assessActions = assessActions.Where(mention =>
+          roCrate.Entities[mention!["@id"]!.ToString()].Properties["additionalType"]?["@id"]?.ToString() ==
+          ActionType.CheckValueType);
+        break;
+      }
       case ActionType.DisclosureCheck:
-        {
-          assessActions = assessActions.Where(mention =>
-            roCrate.Entities[mention!["@id"]!.ToString()].Properties["additionalType"]?["@id"]?.ToString() ==
-            ActionType.DisclosureCheck);
-          break;
-        }
+      {
+        assessActions = assessActions.Where(mention =>
+          roCrate.Entities[mention!["@id"]!.ToString()].Properties["additionalType"]?["@id"]?.ToString() ==
+          ActionType.DisclosureCheck);
+        break;
+      }
       case ActionType.SignOff:
-        {
-          assessActions = assessActions.Where(mention =>
-            roCrate.Entities[mention!["@id"]!.ToString()].Properties["additionalType"]?["@id"]?.ToString() ==
-            ActionType.SignOff);
-          break;
-        }
+      {
+        assessActions = assessActions.Where(mention =>
+          roCrate.Entities[mention!["@id"]!.ToString()].Properties["additionalType"]?["@id"]?.ToString() ==
+          ActionType.SignOff);
+        break;
+      }
       case ActionType.ValidationCheck:
-        {
-          assessActions = assessActions.Where(mention =>
-            roCrate.Entities[mention!["@id"]!.ToString()].Properties["additionalType"]?["@id"]?.ToString() ==
-            ActionType.ValidationCheck);
-          break;
-        }
+      {
+        assessActions = assessActions.Where(mention =>
+          roCrate.Entities[mention!["@id"]!.ToString()].Properties["additionalType"]?["@id"]?.ToString() ==
+          ActionType.ValidationCheck);
+        break;
+      }
       case ActionType.GenerateCheckValue:
-        {
-          assessActions = assessActions.Where(mention =>
-            roCrate.Entities[mention!["@id"]!.ToString()].Properties["additionalType"]?["@id"]?.ToString() ==
-            ActionType.GenerateCheckValue);
-          break;
-        }
+      {
+        assessActions = assessActions.Where(mention =>
+          roCrate.Entities[mention!["@id"]!.ToString()].Properties["additionalType"]?["@id"]?.ToString() ==
+          ActionType.GenerateCheckValue);
+        break;
+      }
     }
 
     var action = assessActions.Select(action => action?["@id"]) ??

--- a/app/HutchAgent/Services/FinalisationService.cs
+++ b/app/HutchAgent/Services/FinalisationService.cs
@@ -20,4 +20,40 @@ public class FinalisationService
     _storeWriter = storeWriter;
     _jobService = jobService;
   }
+
+  /// <summary>
+  /// Merge a result crate from a workflow run back into its input crate.
+  /// </summary>
+  /// <param name="jobId"></param>
+  public async Task MergeCrate(string jobId)
+  {
+    throw new NotImplementedException();
+  }
+
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <param name="jobId"></param>
+  public async Task MakeChecksums(string jobId)
+  {
+    throw new NotImplementedException();
+  }
+
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <param name="jobId"></param>
+  public async Task UpdateMetadata(string jobId)
+  {
+    throw new NotImplementedException();
+  }
+
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <param name="jobId"></param>
+  public async Task UploadToStore(string jobId)
+  {
+    throw new NotImplementedException();
+  }
 }

--- a/app/HutchAgent/Services/FinalisationService.cs
+++ b/app/HutchAgent/Services/FinalisationService.cs
@@ -31,12 +31,14 @@ public class FinalisationService
   }
 
   /// <summary>
-  /// 
+  /// Make the checksums for the BagIt containing the job's data.
   /// </summary>
-  /// <param name="jobId"></param>
+  /// <param name="jobId">The ID of the job needing checksums.</param>
   public async Task MakeChecksums(string jobId)
   {
-    throw new NotImplementedException();
+    var job = await _jobService.Get(jobId);
+    await _bagItService.WriteManifestSha512(job.WorkingDirectory);
+    await _bagItService.WriteTagManifestSha512(job.WorkingDirectory);
   }
 
   /// <summary>

--- a/app/HutchAgent/Services/FinalisationService.cs
+++ b/app/HutchAgent/Services/FinalisationService.cs
@@ -51,10 +51,23 @@ public class FinalisationService
   /// <summary>
   /// Merge a result crate from a workflow run back into its input crate.
   /// </summary>
-  /// <param name="jobId"></param>
+  /// <param name="jobId">The ID of the workflow run that needs merging.</param>
   public async Task MergeCrate(string jobId)
   {
-    throw new NotImplementedException();
+    var job = await _jobService.Get(jobId);
+
+    // Path the to the job outputs
+    var executionCratePath = Path.Combine(
+      _wfexsWorkDir,
+      job.ExecutorRunId,
+      "outputs",
+      "execution.crate.zip");
+
+    var mergeIntoPath = Path.Combine(
+      job.WorkingDirectory.BagItPayloadPath(),
+      "outputs");
+
+    _crateService.MergeCrates(executionCratePath, mergeIntoPath);
   }
 
   /// <summary>

--- a/app/HutchAgent/Services/FinalisationService.cs
+++ b/app/HutchAgent/Services/FinalisationService.cs
@@ -70,12 +70,25 @@ public class FinalisationService
   /// <param name="jobId"></param>
   public async Task Finalise(string jobId)
   {
-    await UpdateJob(jobId);
-    await MergeCrate(jobId);
-    await UpdateMetadata(jobId);
-    await DisclosureCheck(jobId);
-    await MakeChecksums(jobId);
-    await UploadToStore(jobId);
+    try
+    {
+      var job = await _jobService.Get(jobId);
+
+      await UpdateJob(jobId);
+      await MergeCrate(jobId);
+      await UpdateMetadata(jobId);
+      await DisclosureCheck(jobId);
+      await MakeChecksums(jobId);
+      await UploadToStore(jobId);
+    }
+    catch (KeyNotFoundException)
+    {
+      _logger.LogError("Could not find job with ID {}", jobId);
+    }
+    catch (Exception)
+    {
+      _logger.LogError("An unexpected error occurred while finalising job {}", jobId);
+    }
   }
 
   /// <summary>

--- a/app/HutchAgent/Services/FinalisationService.cs
+++ b/app/HutchAgent/Services/FinalisationService.cs
@@ -51,6 +51,15 @@ public class FinalisationService
     _logger.LogInformation($"Found working directory {_wfexsWorkDir}");
   }
 
+  public async Task Finalise(string jobId)
+  {
+    await UpdateJob(jobId);
+    await MergeCrate(jobId);
+    await UpdateMetadata(jobId);
+    await MakeChecksums(jobId);
+    await UploadToStore(jobId);
+  }
+
   /// <summary>
   /// Merge a result crate from a workflow run back into its input crate.
   /// </summary>

--- a/app/HutchAgent/Services/FinalisationService.cs
+++ b/app/HutchAgent/Services/FinalisationService.cs
@@ -1,0 +1,21 @@
+namespace HutchAgent.Services;
+
+public class FinalisationService
+{
+  private readonly BagItService _bagItService;
+  private readonly CrateService _crateService;
+  private readonly ILogger<FinalisationService> _logger;
+  private readonly IResultsStoreWriter _storeWriter;
+
+  public FinalisationService(
+    BagItService bagItService,
+    CrateService crateService,
+    ILogger<FinalisationService> logger,
+    IResultsStoreWriter storeWriter)
+  {
+    _bagItService = bagItService;
+    _crateService = crateService;
+    _logger = logger;
+    _storeWriter = storeWriter;
+  }
+}

--- a/app/HutchAgent/Services/FinalisationService.cs
+++ b/app/HutchAgent/Services/FinalisationService.cs
@@ -62,6 +62,7 @@ public class FinalisationService
   /// <item>Update the state with the start and end times, and the exit code</item>
   /// <item>Merge the results RO-Crate into the input RO-Crate</item>
   /// <item>Update the metadata of the input RO-Crate with the outputs of the workflow run.</item>
+  /// <item>Perform disclosure checks on the BagIt.</item>
   /// <item>Re-write the checksums of the BagIt containing the inputs and outputs.</item>
   /// <item>Upload a zipped BagIt to the results store.</item>
   /// </list>
@@ -72,6 +73,7 @@ public class FinalisationService
     await UpdateJob(jobId);
     await MergeCrate(jobId);
     await UpdateMetadata(jobId);
+    await DisclosureCheck(jobId);
     await MakeChecksums(jobId);
     await UploadToStore(jobId);
   }
@@ -220,5 +222,18 @@ public class FinalisationService
 
     // update job in DB
     await _jobService.Set(job);
+  }
+
+  /// <summary>
+  /// Perform disclosure checks for a given job.
+  /// </summary>
+  /// <param name="jobId">The job needing disclosure checks.</param>
+  private async Task DisclosureCheck(string jobId)
+  {
+    var job = await _jobService.Get(jobId);
+
+    var crate = _crateService.InitialiseCrate(job.WorkingDirectory.BagItPayloadPath());
+    _crateService.CreateDisclosureCheck(crate);
+    crate.Save(job.WorkingDirectory.BagItPayloadPath());
   }
 }

--- a/app/HutchAgent/Services/FinalisationService.cs
+++ b/app/HutchAgent/Services/FinalisationService.cs
@@ -6,16 +6,18 @@ public class FinalisationService
   private readonly CrateService _crateService;
   private readonly ILogger<FinalisationService> _logger;
   private readonly IResultsStoreWriter _storeWriter;
+  private readonly WorkflowJobService _jobService;
 
   public FinalisationService(
     BagItService bagItService,
     CrateService crateService,
     ILogger<FinalisationService> logger,
-    IResultsStoreWriter storeWriter)
+    IResultsStoreWriter storeWriter, WorkflowJobService jobService)
   {
     _bagItService = bagItService;
     _crateService = crateService;
     _logger = logger;
     _storeWriter = storeWriter;
+    _jobService = jobService;
   }
 }

--- a/app/HutchAgent/Services/FinalisationService.cs
+++ b/app/HutchAgent/Services/FinalisationService.cs
@@ -140,10 +140,9 @@ public class FinalisationService
   {
     var job = await _jobService.Get(jobId);
     var bagitDir = new DirectoryInfo(job.WorkingDirectory);
-    var bagitParent = bagitDir.Parent ??
-                      throw new DirectoryNotFoundException($"Cannot find parent directory of {bagitDir.FullName}");
+    var bagitParent = Path.Combine(_pathOptions.WorkingDirectoryBase, _pathOptions.Jobs);
     var pathToZip = Path.Combine(
-      bagitParent.FullName,
+      bagitParent,
       Path.TrimEndingDirectorySeparator(bagitDir.FullName) + ".zip"
     );
 

--- a/app/HutchAgent/Services/WorkflowJobService.cs
+++ b/app/HutchAgent/Services/WorkflowJobService.cs
@@ -41,14 +41,14 @@ public class WorkflowJobService
     return await _db.WorkflowJobs
       .AsNoTracking()
       .Select(entity => new Models.WorkflowJob
-      {
-        Id = entity.Id,
-        WorkingDirectory = entity.WorkingDirectory,
-        ExecutorRunId = entity.ExecutorRunId,
-        ExitCode = entity.ExitCode,
-        ExecutionStartTime = entity.ExecutionStartTime,
-        EndTime = entity.EndTime
-      }
+        {
+          Id = entity.Id,
+          WorkingDirectory = entity.WorkingDirectory,
+          ExecutorRunId = entity.ExecutorRunId,
+          ExitCode = entity.ExitCode,
+          ExecutionStartTime = entity.ExecutionStartTime,
+          EndTime = entity.EndTime
+        }
       ).ToListAsync();
   }
 
@@ -57,10 +57,20 @@ public class WorkflowJobService
   /// </summary>
   /// <param name="jobId">The ID of the <see cref="WorkflowJob"/> to be retrieved from the database.</param>
   /// <returns><see cref="Models.WorkflowJob"/> with the requested ID.</returns>
-  public async Task<WorkflowJob> Get(string jobId)
+  public async Task<Models.WorkflowJob> Get(string jobId)
   {
-    return await _db.WorkflowJobs.FindAsync(jobId)
-      ?? throw new KeyNotFoundException();
+    var entity = await _db.WorkflowJobs.FindAsync(jobId)
+                 ?? throw new KeyNotFoundException();
+    var job = new Models.WorkflowJob
+    {
+      Id = entity.Id,
+      ExecutionStartTime = entity.ExecutionStartTime,
+      EndTime = entity.EndTime,
+      ExecutorRunId = entity.ExecutorRunId,
+      ExitCode = entity.ExitCode,
+      WorkingDirectory = entity.WorkingDirectory
+    };
+    return job;
   }
 
   /// <summary>


### PR DESCRIPTION
## Overview

Create new `FinalisationService` to handle post-execution steps of workflow runs.

The service handles updating the the job state in the local database, merging run outputs back to the input crate, updating the metadata of the crate, rewriting the bagit checksums, and uploading to the results store.

## Azure Boards

- AB#124796
- AB#124797
- AB#124798
- AB#124799
- AB#124800
- AB#124908
- AB#124909
- AB#124910
