### PR TITLE
AB#124919: Github workflows target wrong dotnet version (remake of #233)

### DIFF
--- a/.github/workflows/build.HutchAgent.yml
+++ b/.github/workflows/build.HutchAgent.yml
@@ -12,7 +12,7 @@ on:
 env:
   # Configure these
   CI_build-config: Debug
-  CI_dotnet-version: 6.0.x
+  CI_dotnet-version: 7.0.x
   Agent_project: ./app/HutchAgent/HutchAgent.csproj
   Agent_test_project: ./app/HutchAgent.Tests/HutchAgent.Tests.csproj
 

--- a/.github/workflows/publish.hutch.yml
+++ b/.github/workflows/publish.hutch.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   CI_build-config: ${{ github.event.inputs.buildConfig || 'release' }}
-  CI_dotnet-version: 6.0.x
+  CI_dotnet-version: 7.0.x
   CI_node-version: "16"
   CI_publish-dir: publish
 
@@ -25,11 +25,11 @@ jobs:
     outputs:
       timestamp: ${{ steps.makestamp.outputs.time }}
     steps:
-    - name: Make Timestamp
-      id: makestamp
-      uses: nanzm/get-time-action@v1.1
-      with:
-        format: "YYYYMMDDHHmmss"
+      - name: Make Timestamp
+        id: makestamp
+        uses: nanzm/get-time-action@v1.1
+        with:
+          format: "YYYYMMDDHHmmss"
 
   publish-manager-docker:
     runs-on: ubuntu-latest
@@ -60,7 +60,6 @@ jobs:
           tags: |
             ${{ env.TS_TAG }}
             ${{ env.NEXT_TAG }}
-
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v3.1.1

--- a/.github/workflows/release.hutch-manager.yml
+++ b/.github/workflows/release.hutch-manager.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   CI_build-config: release
-  CI_dotnet-version: 6.0.x
+  CI_dotnet-version: 7.0.x
   CI_node-version: "16"
   CI_publish-dir: publish
 

--- a/.github/workflows/version.hutch-manager.yml
+++ b/.github/workflows/version.hutch-manager.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   CI_build-config: release
-  CI_dotnet-version: 6.0.x
+  CI_dotnet-version: 7.0.x
   CI_node-version: "16"
   CI_publish-dir: publish
 
@@ -57,7 +57,7 @@ jobs:
         with:
           dotnet-version: ${{ env.CI_dotnet-version }}
       - name: Bump Version
-        run: >- 
+        run: >-
           pnpm dlx dotnet-bump
           ${{ needs.get-version.outputs.VERSION_TAG }}
           --no-commit 

--- a/app/HutchAgent.Tests/TestBagItService.cs
+++ b/app/HutchAgent.Tests/TestBagItService.cs
@@ -35,7 +35,7 @@ public class TestBagItService : IClassFixture<ManifestFixture>, IClassFixture<Ta
 
     // Act
     await service.WriteManifestSha512(_manifestFixture.Dir.FullName);
-    var lines = await File.ReadAllLinesAsync(_manifestFixture.ManifestPath);
+    var lines = File.ReadAllLines(_manifestFixture.ManifestPath);
     var hashes = from x in lines select x.Split("  ").First();
 
     // Assert
@@ -50,7 +50,7 @@ public class TestBagItService : IClassFixture<ManifestFixture>, IClassFixture<Ta
 
     // Act
     await service.WriteManifestSha512(_manifestFixture.Dir.FullName);
-    var lines = await File.ReadAllLinesAsync(_manifestFixture.ManifestPath);
+    var lines = File.ReadAllLines(_manifestFixture.ManifestPath);
     var paths = from x in lines select x.Split("  ").Last();
 
     // Assert
@@ -78,7 +78,7 @@ public class TestBagItService : IClassFixture<ManifestFixture>, IClassFixture<Ta
     
     // Act
     await service.WriteTagManifestSha512(_tagManifestFixture.Dir.FullName);
-    var lines = await File.ReadAllLinesAsync(_tagManifestFixture.TagManifestPath);
+    var lines = File.ReadAllLines(_tagManifestFixture.TagManifestPath);
     var hashes = from x in lines select x.Split("  ").First();
 
     // Assert
@@ -93,7 +93,7 @@ public class TestBagItService : IClassFixture<ManifestFixture>, IClassFixture<Ta
     
     // Act
     await service.WriteTagManifestSha512(_tagManifestFixture.Dir.FullName);
-    var lines = await File.ReadAllLinesAsync(_tagManifestFixture.TagManifestPath);
+    var lines = File.ReadAllLines(_tagManifestFixture.TagManifestPath);
     var paths = from x in lines select x.Split("  ").Last();
 
     // Assert

--- a/app/HutchAgent.Tests/TestBagItService.cs
+++ b/app/HutchAgent.Tests/TestBagItService.cs
@@ -35,11 +35,14 @@ public class TestBagItService : IClassFixture<ManifestFixture>, IClassFixture<Ta
 
     // Act
     await service.WriteManifestSha512(_manifestFixture.Dir.FullName);
-    var lines = File.ReadAllLines(_manifestFixture.ManifestPath);
+    var lines = await File.ReadAllLinesAsync(_manifestFixture.ManifestPath);
     var hashes = from x in lines select x.Split("  ").First();
 
     // Assert
-    Assert.Equal(_manifestFixture.ExpectedHashes, hashes.ToArray());
+    foreach (var h in hashes.ToArray())
+    {
+      Assert.Contains(h, _manifestFixture.ExpectedHashes);
+    }
   }
 
   [Fact]
@@ -50,11 +53,14 @@ public class TestBagItService : IClassFixture<ManifestFixture>, IClassFixture<Ta
 
     // Act
     await service.WriteManifestSha512(_manifestFixture.Dir.FullName);
-    var lines = File.ReadAllLines(_manifestFixture.ManifestPath);
+    var lines = await File.ReadAllLinesAsync(_manifestFixture.ManifestPath);
     var paths = from x in lines select x.Split("  ").Last();
 
     // Assert
-    Assert.Equal(_manifestFixture.ExpectedPaths, paths.ToArray());
+    foreach (var p in paths.ToArray())
+    {
+      Assert.Contains(p, _manifestFixture.ExpectedPaths);
+    }
   }
 
   [Fact]
@@ -78,11 +84,14 @@ public class TestBagItService : IClassFixture<ManifestFixture>, IClassFixture<Ta
     
     // Act
     await service.WriteTagManifestSha512(_tagManifestFixture.Dir.FullName);
-    var lines = File.ReadAllLines(_tagManifestFixture.TagManifestPath);
+    var lines = await File.ReadAllLinesAsync(_tagManifestFixture.TagManifestPath);
     var hashes = from x in lines select x.Split("  ").First();
 
     // Assert
-    Assert.Equal(_tagManifestFixture.ExpectedHashes, hashes.ToArray());
+    foreach (var h in hashes.ToArray())
+    {
+      Assert.Contains(h, _tagManifestFixture.ExpectedHashes);
+    }
   }
 
   [Fact]
@@ -93,11 +102,14 @@ public class TestBagItService : IClassFixture<ManifestFixture>, IClassFixture<Ta
     
     // Act
     await service.WriteTagManifestSha512(_tagManifestFixture.Dir.FullName);
-    var lines = File.ReadAllLines(_tagManifestFixture.TagManifestPath);
+    var lines = await File.ReadAllLinesAsync(_tagManifestFixture.TagManifestPath);
     var paths = from x in lines select x.Split("  ").Last();
 
     // Assert
-    Assert.Equal(_tagManifestFixture.ExpectedPaths, paths.ToArray());
+    foreach (var p in paths.ToArray())
+    {
+      Assert.Contains(p, _tagManifestFixture.ExpectedPaths);
+    }
   }
 }
 


### PR DESCRIPTION
## Overview

- Github workflows to target .NET7
- `HutchAgent.Tests` to target .NET7
- Fix failing unit tests

## Azure Boards

- AB#124920
- AB#124921
