### PR TITLE
AB#125997: Set ansible to include dotnet 7 and EF

### DIFF
--- a/ansible/playbooks/set-up-vm.yml
+++ b/ansible/playbooks/set-up-vm.yml
@@ -21,8 +21,8 @@
       become: true
       ansible.builtin.apt:
         name:
-          - dotnet-sdk-6.0
-          - aspnetcore-runtime-6.0
+          - dotnet-sdk-7.0
+          - aspnetcore-runtime-7.0
 
     - name: Add nginx.conf
       ansible.builtin.copy:

--- a/ansible/playbooks/set-up-vm.yml
+++ b/ansible/playbooks/set-up-vm.yml
@@ -24,6 +24,11 @@
           - dotnet-sdk-7.0
           - aspnetcore-runtime-7.0
 
+    - name: Install Entity Framework
+      become: true
+      ansible.builtin.command:
+        cmd: dotnet tool install --global dotnet-ef --version 7.*
+
     - name: Add nginx.conf
       ansible.builtin.copy:
         src: files/nginx.conf

--- a/ansible/playbooks/set-up-vm.yml
+++ b/ansible/playbooks/set-up-vm.yml
@@ -24,11 +24,6 @@
           - dotnet-sdk-7.0
           - aspnetcore-runtime-7.0
 
-    - name: Install Entity Framework
-      become: true
-      ansible.builtin.command:
-        cmd: dotnet tool install --global dotnet-ef --version 7.*
-
     - name: Add nginx.conf
       ansible.builtin.copy:
         src: files/nginx.conf


### PR DESCRIPTION
## Overview

Install .NET 7 with ansible as well as entity framework.

## Azure Boards

- AB#125998
- AB#125999
- AB#126000
