### PR TITLE
AB#126039: Not using IOptions in ExecuteActionHandler and FinaliseActionHandler

### DIFF
--- a/app/HutchAgent/HostedServices/QueuePollingHostedService.cs
+++ b/app/HutchAgent/HostedServices/QueuePollingHostedService.cs
@@ -37,7 +37,7 @@ public class QueuePollingHostedService : BackgroundService
       {
         var queue = _serviceProvider.GetRequiredService<IQueueReader>();
         var executeActionHandler = scope.ServiceProvider.GetRequiredService<ExecuteActionHandler>();
-        var finalisationService = scope.ServiceProvider.GetRequiredService<FinalisationService>();
+        var finalisationService = scope.ServiceProvider.GetRequiredService<FinaliseActionHandler>();
 
         // If a thread is available, per Max Parallelism, then
         // Pop a queue message, and Execute its action on the free thread

--- a/app/HutchAgent/Program.cs
+++ b/app/HutchAgent/Program.cs
@@ -42,7 +42,7 @@ builder.Services
   .AddSingleton<BagItService>()
   .AddTransient<IQueueWriter, RabbitQueueWriter>()
   .AddTransient<IQueueReader, RabbitQueueReader>()
-  .AddScoped<FinalisationService>()
+  .AddScoped<FinaliseActionHandler>()
   .AddFeatureManagement();
 
 #endregion

--- a/app/HutchAgent/Services/ExecuteActionHandler.cs
+++ b/app/HutchAgent/Services/ExecuteActionHandler.cs
@@ -1,6 +1,7 @@
 using HutchAgent.Config;
 using HutchAgent.Constants;
 using HutchAgent.Models;
+using Microsoft.Extensions.Options;
 
 namespace HutchAgent.Services;
 
@@ -18,14 +19,14 @@ public class ExecuteActionHandler
     WorkflowTriggerService workflowTriggerService,
     WorkflowJobService workflowJobService,
     IQueueWriter queueWriter,
-    JobActionsQueueOptions queueOptions,
+    IOptions<JobActionsQueueOptions> queueOptions,
     CrateService crates)
   {
     _workflowFetchService = workflowFetchService;
     _workflowTriggerService = workflowTriggerService;
     _workflowJobService = workflowJobService;
     _queueWriter = queueWriter;
-    _queueOptions = queueOptions;
+    _queueOptions = queueOptions.Value;
     _crates = crates;
   }
 

--- a/app/HutchAgent/Services/FinaliseActionHandler.cs
+++ b/app/HutchAgent/Services/FinaliseActionHandler.cs
@@ -8,11 +8,11 @@ using YamlDotNet.RepresentationModel;
 
 namespace HutchAgent.Services;
 
-public class FinalisationService
+public class FinaliseActionHandler
 {
   private readonly BagItService _bagItService;
   private readonly CrateService _crateService;
-  private readonly ILogger<FinalisationService> _logger;
+  private readonly ILogger<FinaliseActionHandler> _logger;
   private readonly IResultsStoreWriter _storeWriter;
   private readonly WorkflowJobService _jobService;
   private readonly PathOptions _pathOptions;
@@ -23,10 +23,10 @@ public class FinalisationService
   private readonly string _wfexsWorkDir;
   private readonly string _statePath = Path.Combine("meta", "execution-state.yaml");
 
-  public FinalisationService(
+  public FinaliseActionHandler(
     BagItService bagItService,
     CrateService crateService,
-    ILogger<FinalisationService> logger,
+    ILogger<FinaliseActionHandler> logger,
     IResultsStoreWriter storeWriter,
     WorkflowJobService jobService,
     IOptions<PathOptions> pathOptions,


### PR DESCRIPTION
## Overview

Add IOptions to ExecuteActionHandler and FinaliseActionHandler (renamed from FinalisationService).

## Azure Boards

- AB#126150
- AB#126152
- AB#126153
