### PR TITLE
AB#130446: docs build runs on dotnet changes for swagger

### DIFF
--- a/.github/workflows/deploy.docs-website.yml
+++ b/.github/workflows/deploy.docs-website.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
     paths:
+      - app/HutchAgent/**
       - website/**
 
 env:


### PR DESCRIPTION
<!--
     ⚠ Ensure the PR title starts with a reference to the primary Azure Boards work item it completes, in the form `AB#<id> My PR Title`.
     
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     PR Guidance:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡️ Optimization
- [x] 📝 Documentation Update

## Description

This PR changes the docs workflow to run when there are changes to HutchAgent as well as to the website source, so that Swagger changes are as up to date as possible.

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why:
    - CI config changes only
- [ ] ❓ I need help with writing tests
