### PR TITLE
AB#130479: Data access (part 1)

### DIFF
--- a/app/HutchAgent/Config/WorkflowTriggerOptions.cs
+++ b/app/HutchAgent/Config/WorkflowTriggerOptions.cs
@@ -29,7 +29,7 @@ public class WorkflowTriggerOptions
   public bool GenerateFullProvenanceCrate { get; set; }
 
   /// <summary>
-  /// The container engine generated stage files should use e.g. `docker` (default) or `podman`.
+  /// The container engine generated stage files should use e.g. `docker` (default), singularity or `podman`.
   /// Should match the `containerType` configured in the Executor's local config.
   /// </summary>
   // TODO enum this

--- a/app/HutchAgent/HutchAgent.csproj
+++ b/app/HutchAgent/HutchAgent.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.0.0-beta.1</Version>
+    <Version>1.0.0-beta.2</Version>
     <!-- Append GitHash to Version if provided -->
     <Version Condition="'$(GitHash)' != ''">$(Version)+$(GitHash)</Version>
   </PropertyGroup>

--- a/app/HutchAgent/Models/DatabaseConnectionDetails.cs
+++ b/app/HutchAgent/Models/DatabaseConnectionDetails.cs
@@ -9,27 +9,57 @@ public class DatabaseConnectionDetails
   /// </summary>
   [Required]
   public string Hostname { get; set; } = string.Empty;
-  
+
   /// <summary>
   /// Database Server Port. Defaults to PostgreSQL Default (5432)
   /// </summary>
   public int Port { get; set; } = 5432;
-  
+
   /// <summary>
   /// Name of the Database to connect to
   /// </summary>
   [Required]
   public string Database { get; set; } = string.Empty;
-  
+
   /// <summary>
   /// Username with access to the database
   /// </summary>
   [Required]
   public string Username { get; set; } = string.Empty;
-  
+
   /// <summary>
   /// Password with access to the database
   /// </summary>
   [Required]
   public string Password { get; set; } = string.Empty;
+}
+
+public static class DatabaseConnectionDetailsExtensions
+{
+  /// <summary>
+  /// <para>
+  /// Get alternatives to `localhost` for the host machine of a given container engine.
+  /// </para>
+  /// <para>
+  /// If the <see cref="DatabaseConnectionDetails" /> <see cref="Host"/> property is not `localhost`
+  /// then no mapping occurs.
+  /// </para>
+  /// <para>
+  /// If the container's localhost (not the host machine's) is desired,
+  /// the loopback address `127.0.0.1` should be used instead to avoid mapping.</para>
+  /// </summary>
+  /// <param name="dataAccess">The <see cref="DatabaseConnectionDetails" /> object.</param>
+  /// <param name="containerEngine">The target container engine.</param>
+  /// <returns></returns>
+  public static string GetContainerHost(this DatabaseConnectionDetails dataAccess, string containerEngine)
+  {
+    return dataAccess.Hostname != "localhost"
+      ? dataAccess.Hostname // if it's not localhost, it's irrelevant; use the configured value
+      : containerEngine switch
+      {
+        "podman" => "host.containers.internal",
+        "docker" or "singularity" => "172.17.0.1",
+        _ => dataAccess.Hostname
+      };
+  }
 }

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -330,16 +330,7 @@ public class WorkflowTriggerService
           {
             value = name.ToString() switch
             {
-              // for db_host we may need to map "localhost" to the container engine's host machine target.
-              // if triggering systems REALLY mean the container's localhost, they can use the loopback ip 127.0.0.1
-              "db_host" => dataAccess.Hostname != "localhost"
-                ? dataAccess.Hostname
-                : _workflowOptions.ContainerEngine switch
-                {
-                  "podman" => "host.containers.internal",
-                  "docker" or "singularity" => "172.17.0.1",
-                  _ => dataAccess.Hostname
-                },
+              "db_host" => dataAccess.GetContainerHost(_workflowOptions.ContainerEngine),
               "db_port" => dataAccess.Port.ToString(),
               "db_name" => dataAccess.Database,
               "db_user" => dataAccess.Username,

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -303,25 +303,61 @@ public class WorkflowTriggerService
       }
       else
       {
-        var value = objectEntity.Properties["value"] ??
+        var value = objectEntity.Properties["value"]?.ToString() ??
                     throw new NullReferenceException("Could not get value for given input parameter.");
 
-        // TODO this is a temporary hack and should instead happen against dbAccess in a job payload
-        // rewrite "localhost" to the container engine appropriate form.
-        // if triggering systems REALLY mean localhost, they can use the loopback ip
-        if (name.ToString() == "db_host" && value.ToString() == "localhost")
-          value = _workflowOptions.ContainerEngine switch
-          {
-            "podman" => "host.containers.internal",
-            "docker" => "172.17.0.1",
-            "singularity" => "localhost",
-            _ => throw new InvalidOperationException(
-              $"Unexpected Container Engine configured: {_workflowOptions.ContainerEngine}")
-          };
 
-        parameters[name.ToString()] = value?.ToString() ??
-                                      throw new NullReferenceException(
-                                        "Could not get value for given input parameter.");
+        // TODO the below is a temporary hack until we test wfexs environment variables
+        // and update workflows and guidance around data access.
+        try
+        {
+          // Basically we currently modify inputs with known names
+          // to have values from the job submission's data access details
+          // instead of what's contained in the job crate.
+          //
+          // This approach does rely on the job crate having the inputs defined,
+          // but they can have dummy values that will be replaced.
+          //
+          // When we switch to environment variables, they won't need defining as inputs or anything
+          // within the job crate; they'll just be added to the execution environment
+          // and optionally used by the workflow if it cares.
+
+          // Try and get the data access details
+          var dataAccess = JsonSerializer.Deserialize<DatabaseConnectionDetails>(workflowJob.DataAccess ?? "");
+
+          // Input value replacements!
+          if (dataAccess is not null)
+          {
+            value = name.ToString() switch
+            {
+              // for db_host we may need to map "localhost" to the container engine's host machine target.
+              // if triggering systems REALLY mean the container's localhost, they can use the loopback ip 127.0.0.1
+              "db_host" => dataAccess.Hostname != "localhost"
+                ? dataAccess.Hostname
+                : _workflowOptions.ContainerEngine switch
+                {
+                  "podman" => "host.containers.internal",
+                  "docker" or "singularity" => "172.17.0.1",
+                  _ => dataAccess.Hostname
+                },
+              "db_port" => dataAccess.Port.ToString(),
+              "db_name" => dataAccess.Database,
+              "db_user" => dataAccess.Username,
+              "db_password" => dataAccess.Password,
+              _ => value // leave it untouched
+            };
+          }
+        }
+        catch (JsonException)
+        {
+          // we've failed to deserialize data access.
+          // not much we can do, but shouldn't stop the job trying to run.
+          // 
+          // it may fail if it intends to try and access the data source,
+          // but that'll get handled and reported in the usual way.
+        }
+
+        parameters[name.ToString()] = value;
       }
     }
 
@@ -352,7 +388,7 @@ public class WorkflowTriggerService
     var stageFilePath = Path.Combine(workflowJob.WorkingDirectory.JobCrateRoot(),
       "hutch_cwl.wfex.stage"); // TODO rename later maybe if we support more than cwl ;)
 
-    // TODO should we write metadata for the stage file?
+    // TODO should we write metadata for the stage file? (yes)
 
     await using var outputStageFile = new StreamWriter(stageFilePath);
     await outputStageFile.WriteLineAsync(yaml);


### PR DESCRIPTION
<!--
     ⚠ Ensure the PR title starts with a reference to the primary Azure Boards work item it completes, in the form `AB#<id> My PR Title`.
     
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     PR Guidance:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡️ Optimization
- [ ] 📝 Documentation Update

## Description

This PR adds the facility for Hutch to consume the data access credentials provided in a job submission, and insert them as workflow inputs.

It requires workflow inputs to be defined with the correct names at this time:

- `db_host`
- `db_port`
- `db_name`
- `db_user`
- `db_password`

in future (AB#130480) these will be moved to environment variables.

## Related Tickets & Documents

- `AB#130480` - This PBI covers the move to environment variable injection, instead of workflow input injection.

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why:
    - no currently testable code added or modified
- [ ] ❓ I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![Data approves of data access](https://media.giphy.com/media/msKNSs8rmJ5m/giphy.gif)
