### PR TITLE
AB#131635: Dummy controller api

### DIFF
--- a/DummyControllerApi/Config/EgressBucketDetailsOptions.cs
+++ b/DummyControllerApi/Config/EgressBucketDetailsOptions.cs
@@ -1,0 +1,7 @@
+namespace DummyControllerApi.Config;
+
+public class EgressBucketDetailsOptions
+{
+  public string Host { get; set; } = "localhost:9000";
+  public string Bucket { get; set; } = "hutch.bucket";
+}

--- a/DummyControllerApi/Controllers/SubmissionController.cs
+++ b/DummyControllerApi/Controllers/SubmissionController.cs
@@ -36,14 +36,12 @@ public class SubmissionController : ControllerBase
   public IActionResult UpdateStatusForTre(
     [FromQuery] string subId,
     [FromQuery] int statusType,
-    [FromQuery] string description)
+    [FromQuery] string? description)
   {
     // Cursory format validation
 
     // TODO we actually don't know what unsuccessful reponses the real API returns under what conditions
     // but the validation here should at least help make sure Hutch's request behaviours are as expected
-
-    if (string.IsNullOrWhiteSpace(subId)) return BadRequest($"Expected a {nameof(subId)}");
 
     if (statusType is < 30 or > 42)
       return BadRequest($"{nameof(statusType)} was outside the expected enum range for Hutch");
@@ -82,11 +80,6 @@ public class SubmissionController : ControllerBase
   [HttpGet("GetOutputBucketInfo")]
   public IActionResult GetOutputBucketInfo([FromQuery] string subId)
   {
-    // TODO we actually don't know what unsuccessful reponses the real API returns under what conditions
-    // but the validation here should at least help make sure Hutch's request behaviours are as expected
-
-    if (string.IsNullOrWhiteSpace(subId)) return BadRequest("Expected a subId");
-
     var details = new EgressBucketResponseModel
     {
       Host = _bucketOptions.Host,

--- a/DummyControllerApi/Controllers/SubmissionController.cs
+++ b/DummyControllerApi/Controllers/SubmissionController.cs
@@ -51,16 +51,18 @@ public class SubmissionController : ControllerBase
   }
 
   [HttpPost("FilesReadyForReview")]
-  public IActionResult FilesReadyForReview([FromQuery] string subId)
+  public IActionResult FilesReadyForReview([FromBody] FilesReadyRequestModel model)
   {
     // TODO we actually don't know what unsuccessful reponses the real API returns under what conditions
     // but the validation here should at least help make sure Hutch's request behaviours are as expected
-    
-    if(string.IsNullOrWhiteSpace(subId)) return BadRequest("Expected a subId");
-    
-    _approvalQueue.Enqueue(subId);
 
-    return Ok(); // Unsure of this response; TODO confirm with swagger
+    if (string.IsNullOrWhiteSpace(model.SubId)) return BadRequest($"Expected a {nameof(model.SubId)}");
+    if (!model.Files.Any())
+      return BadRequest($"Expected at least one file in {nameof(model.Files)}");
+
+    _approvalQueue.Enqueue(model.SubId); // TODO could persist the file list later for funzies but rn Hutch doesn't care
+
+    return Ok(); // Unsure of this response body and code; TODO confirm with swagger
 
     // TODO presumably we'll need to queue a delayed task that responds with approval
     // AFTER this endpoint gives a response
@@ -72,9 +74,9 @@ public class SubmissionController : ControllerBase
   {
     // TODO we actually don't know what unsuccessful reponses the real API returns under what conditions
     // but the validation here should at least help make sure Hutch's request behaviours are as expected
-    
-    if(string.IsNullOrWhiteSpace(subId)) return BadRequest("Expected a subId");
-    
+
+    if (string.IsNullOrWhiteSpace(subId)) return BadRequest("Expected a subId");
+
     // Unknown what encoding etc is expected here; just the content - TODO confirm with Swagger
     return Ok(new EgressBucketResponseModel
     {

--- a/DummyControllerApi/Controllers/SubmissionController.cs
+++ b/DummyControllerApi/Controllers/SubmissionController.cs
@@ -1,24 +1,51 @@
+using System.Text.Json;
+using DummyControllerApi.Config;
+using DummyControllerApi.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace DummyControllerApi.Controllers;
+
+// Disclaimer:
+// Much of this controller is not how I would expect to conventionally build an ASP.NET Core API
+// or a REST API at all for that matter (query string parameters, much?)
+// However it is vital it matches the specification of the TRE Controller API for testing interactions.
 
 [ApiController]
 [Route("api/[controller]")]
 public class SubmissionController : ControllerBase
 {
   private readonly ILogger<SubmissionController> _logger;
+  private readonly EgressBucketDetailsOptions _bucketOptions;
 
-  public SubmissionController(ILogger<SubmissionController> logger)
+  public SubmissionController(
+    ILogger<SubmissionController> logger,
+    IOptions<EgressBucketDetailsOptions> bucketOptions)
   {
     _logger = logger;
+    _bucketOptions = bucketOptions.Value;
   }
 
   [HttpPost("UpdateStatusForTre")]
-  public async Task<IActionResult> UpdateStatusForTre()
+  public async Task<IActionResult> UpdateStatusForTre(
+    [FromQuery] string subId,
+    [FromQuery] int statusType,
+    [FromQuery] string description)
   {
-    
+    // Cursory format validation
+
+    // TODO we actually don't know what unsuccessful reponses the real API returns under what conditions
+    // but the validation here should at least help make sure Hutch's request behaviours are as expected
+
+    if (string.IsNullOrWhiteSpace(subId)) return BadRequest("Expected a subId");
+
+    if (statusType is < 30 or > 42)
+      return BadRequest("Status Type was outside the expected enum range for Hutch");
+
+    // documented return type is a `text/plain` encoded json object :S
+    return Ok(JsonSerializer.Serialize(new UpdateStatusResponseModel()));
   }
-  
+
   [HttpPost("FilesReadyForReview")]
   public async Task<IActionResult> FilesReadyForReview([FromQuery] string subId)
   {
@@ -26,10 +53,21 @@ public class SubmissionController : ControllerBase
     // AFTER this endpoint gives a response
     // so that Hutch is ready for the /approval request
   }
-  
+
   [HttpGet("GetOutputBucketInfo")]
-  public async Task<IActionResult> GetOutputBucketInfo([FromQuery] string subId)
+  public IActionResult GetOutputBucketInfo([FromQuery] string subId)
   {
-    // TODO where will we get the details? just the default configured store i guess
+    // TODO we actually don't know what unsuccessful reponses the real API returns under what conditions
+    // but the validation here should at least help make sure Hutch's request behaviours are as expected
+    
+    if(string.IsNullOrWhiteSpace(subId))
+      return BadRequest("Expected a subId");
+    
+    // Unknown what encoding etc is expected here; just the content
+    return Ok(new EgressBucketResponseModel
+    {
+      Host = _bucketOptions.Host,
+      Bucket = _bucketOptions.Bucket
+    });
   }
 }

--- a/DummyControllerApi/Controllers/SubmissionController.cs
+++ b/DummyControllerApi/Controllers/SubmissionController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace DummyControllerApi.Controllers;
+
+[ApiController]
+public class SubmissionController : ControllerBase
+{
+  private readonly ILogger<SubmissionController> _logger;
+
+  public SubmissionController(ILogger<SubmissionController> logger)
+  {
+    _logger = logger;
+  }
+}

--- a/DummyControllerApi/Controllers/SubmissionController.cs
+++ b/DummyControllerApi/Controllers/SubmissionController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace DummyControllerApi.Controllers;
 
 [ApiController]
+[Route("api/[controller]")]
 public class SubmissionController : ControllerBase
 {
   private readonly ILogger<SubmissionController> _logger;
@@ -10,5 +11,25 @@ public class SubmissionController : ControllerBase
   public SubmissionController(ILogger<SubmissionController> logger)
   {
     _logger = logger;
+  }
+
+  [HttpPost("UpdateStatusForTre")]
+  public async Task<IActionResult> UpdateStatusForTre()
+  {
+    
+  }
+  
+  [HttpPost("FilesReadyForReview")]
+  public async Task<IActionResult> FilesReadyForReview([FromQuery] string subId)
+  {
+    // TODO presumably we'll need to queue a delayed task that responds with approval
+    // AFTER this endpoint gives a response
+    // so that Hutch is ready for the /approval request
+  }
+  
+  [HttpGet("GetOutputBucketInfo")]
+  public async Task<IActionResult> GetOutputBucketInfo([FromQuery] string subId)
+  {
+    // TODO where will we get the details? just the default configured store i guess
   }
 }

--- a/DummyControllerApi/Controllers/SubmissionController.cs
+++ b/DummyControllerApi/Controllers/SubmissionController.cs
@@ -12,6 +12,8 @@ namespace DummyControllerApi.Controllers;
 // or a REST API at all for that matter (query string parameters, much?)
 // However it is vital it matches the specification of the TRE Controller API for testing interactions.
 
+// TODO Token Auth
+
 [ApiController]
 [Route("api/[controller]")]
 public class SubmissionController : ControllerBase
@@ -46,6 +48,12 @@ public class SubmissionController : ControllerBase
     if (statusType is < 30 or > 42)
       return BadRequest($"{nameof(statusType)} was outside the expected enum range for Hutch");
 
+    _logger.LogInformation(
+      "Submission [{SubId}] Status update: {StatusId} ({Description})",
+      subId,
+      statusType,
+      description);
+
     // documented return type is a `text/plain` encoded json object :S
     return Ok(JsonSerializer.Serialize(new UpdateStatusResponseModel()));
   }
@@ -62,6 +70,8 @@ public class SubmissionController : ControllerBase
 
     _approvalQueue.Enqueue(model.SubId); // TODO could persist the file list later for funzies but rn Hutch doesn't care
 
+    _logger.LogInformation("Submission [{SubId}] Files Queued for Approval", model.SubId);
+    
     return Ok(); // Unsure of this response body and code; TODO confirm with swagger
 
     // TODO presumably we'll need to queue a delayed task that responds with approval
@@ -77,11 +87,18 @@ public class SubmissionController : ControllerBase
 
     if (string.IsNullOrWhiteSpace(subId)) return BadRequest("Expected a subId");
 
-    // Unknown what encoding etc is expected here; just the content - TODO confirm with Swagger
-    return Ok(new EgressBucketResponseModel
+    var details = new EgressBucketResponseModel
     {
       Host = _bucketOptions.Host,
       Bucket = _bucketOptions.Bucket
-    });
+    };
+    
+    _logger.LogInformation(
+      "Submission [{SubId}] Egress Bucket Requested: {Details}",
+      subId,
+      JsonSerializer.Serialize(details));
+
+    // Unknown what encoding etc is expected here; just the content - TODO confirm with Swagger
+    return Ok(details);
   }
 }

--- a/DummyControllerApi/Controllers/SubmissionController.cs
+++ b/DummyControllerApi/Controllers/SubmissionController.cs
@@ -12,8 +12,6 @@ namespace DummyControllerApi.Controllers;
 // or a REST API at all for that matter (query string parameters, much?)
 // However it is vital it matches the specification of the TRE Controller API for testing interactions.
 
-// TODO Token Auth
-
 [ApiController]
 [Route("api/[controller]")]
 public class SubmissionController : ControllerBase
@@ -66,15 +64,15 @@ public class SubmissionController : ControllerBase
     if (!model.Files.Any())
       return BadRequest($"Expected at least one file in {nameof(model.Files)}");
 
+
+    // We need to queue a delayed task that responds with approval
+    // AFTER this endpoint gives a response
+    // so that Hutch is ready for the /approval request
     _approvalQueue.Enqueue(model.SubId); // TODO could persist the file list later for funzies but rn Hutch doesn't care
 
     _logger.LogInformation("Submission [{SubId}] Files Queued for Approval", model.SubId);
     
     return Ok(); // Unsure of this response body and code; TODO confirm with swagger
-
-    // TODO presumably we'll need to queue a delayed task that responds with approval
-    // AFTER this endpoint gives a response
-    // so that Hutch is ready for the /approval request
   }
 
   [HttpGet("GetOutputBucketInfo")]

--- a/DummyControllerApi/DummyControllerApi.csproj
+++ b/DummyControllerApi/DummyControllerApi.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    </ItemGroup>
+
+</Project>

--- a/DummyControllerApi/DummyControllerApi.csproj
+++ b/DummyControllerApi/DummyControllerApi.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Flurl.Http" Version="3.2.4" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>

--- a/DummyControllerApi/DummyControllerApi.csproj
+++ b/DummyControllerApi/DummyControllerApi.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Flurl.Http" Version="3.2.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.12" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>

--- a/DummyControllerApi/Models/EgressBucketResponseModel.cs
+++ b/DummyControllerApi/Models/EgressBucketResponseModel.cs
@@ -1,0 +1,13 @@
+namespace DummyControllerApi.Models;
+
+public class EgressBucketResponseModel
+{
+  public string Host { get; set; } = string.Empty;
+  public string Bucket { get; set; } = string.Empty;
+  
+  /// <summary>
+  /// A real TRE Controller API is unlikely to provide this (even though Hutch will accept it)
+  /// but since this is for development use, it's the default for us to send it here
+  /// </summary>
+  public bool Secure { get; set; } = false;
+}

--- a/DummyControllerApi/Models/FilesReadyRequestModel.cs
+++ b/DummyControllerApi/Models/FilesReadyRequestModel.cs
@@ -1,0 +1,7 @@
+namespace DummyControllerApi.Models;
+
+public class FilesReadyRequestModel
+{
+  public string SubId { get; set; } = string.Empty;
+  public List<string> Files { get; set; } = new();
+}

--- a/DummyControllerApi/Models/HutchApprovalRequestModel.cs
+++ b/DummyControllerApi/Models/HutchApprovalRequestModel.cs
@@ -1,0 +1,7 @@
+namespace DummyControllerApi.Models;
+
+public class HutchApprovalRequestModel
+{
+  public string Status { get; set; } = "FullyApproved";
+  public Dictionary<string, bool> Files { get; set; } = new();
+}

--- a/DummyControllerApi/Models/UpdateStatusResponseModel.cs
+++ b/DummyControllerApi/Models/UpdateStatusResponseModel.cs
@@ -1,0 +1,7 @@
+namespace DummyControllerApi.Models;
+
+public class UpdateStatusResponseModel
+{
+  public bool boolResponse { get; set; } = true;
+  public int returnType { get; set; }
+}

--- a/DummyControllerApi/Program.cs
+++ b/DummyControllerApi/Program.cs
@@ -1,0 +1,25 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+  app.UseSwagger();
+  app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/DummyControllerApi/Program.cs
+++ b/DummyControllerApi/Program.cs
@@ -1,4 +1,5 @@
 using DummyControllerApi.Config;
+using DummyControllerApi.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,6 +11,10 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+
+// Use this for delaying approvals while running
+builder.Services.AddSingleton<InMemoryApprovalQueue>();
 
 var app = builder.Build();
 

--- a/DummyControllerApi/Program.cs
+++ b/DummyControllerApi/Program.cs
@@ -12,9 +12,10 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-
-// Use this for delaying approvals while running
-builder.Services.AddSingleton<InMemoryApprovalQueue>();
+// Use this combo for delaying approvals while running
+builder.Services
+  .AddSingleton<InMemoryApprovalQueue>()
+  .AddHostedService<EgressApprovalHostedService>();
 
 var app = builder.Build();
 

--- a/DummyControllerApi/Program.cs
+++ b/DummyControllerApi/Program.cs
@@ -30,10 +30,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         RequireAudience = true,
       };
     });
-builder.Services.AddAuthorization(o =>
-{
-  //o.DefaultPolicy = ;
-});
+builder.Services.AddAuthorization();
 
 // Configure Options Models
 builder.Services.Configure<EgressBucketDetailsOptions>(builder.Configuration.GetSection("EgressBucketDetails"));

--- a/DummyControllerApi/Program.cs
+++ b/DummyControllerApi/Program.cs
@@ -1,16 +1,41 @@
 using DummyControllerApi.Config;
 using DummyControllerApi.Services;
+using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
 
+// Auth
+builder.Services.AddAuthentication()
+  .AddJwtBearer(
+    opts =>
+    {
+      opts.TokenValidationParameters = new TokenValidationParameters
+      {
+        // TODO we're not interested in actually checking in with whatever idp is in use
+        // we just want to confirm Hutch is sending a token
+        // everything else will be environment setup dependent anyway
+        ValidateIssuer = false,
+        ValidateIssuerSigningKey = false,
+        RequireExpirationTime = true
+      };
+    });
+builder.Services.AddAuthorization(o =>
+{
+  //o.DefaultPolicy = ;
+});
+
+// Configure Options Models
 builder.Services.Configure<EgressBucketDetailsOptions>(builder.Configuration.GetSection("EgressBucketDetails"));
 
+// MVC and stuff
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+
+// Application Services
 
 // Use this combo for delaying approvals while running
 builder.Services
@@ -28,8 +53,10 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-app.UseAuthorization();
+app
+  .UseAuthentication()
+  .UseAuthorization();
 
-app.MapControllers();
+app.MapControllers().RequireAuthorization();
 
 app.Run();

--- a/DummyControllerApi/Program.cs
+++ b/DummyControllerApi/Program.cs
@@ -1,23 +1,33 @@
+using System.IdentityModel.Tokens.Jwt;
 using DummyControllerApi.Config;
 using DummyControllerApi.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
 
 // Auth
-builder.Services.AddAuthentication()
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
   .AddJwtBearer(
     opts =>
     {
       opts.TokenValidationParameters = new TokenValidationParameters
       {
-        // TODO we're not interested in actually checking in with whatever idp is in use
-        // we just want to confirm Hutch is sending a token
-        // everything else will be environment setup dependent anyway
+        // We basically validate nothing about the token to avoid needing extra config about oidc.
+        // We just want to confirm Hutch is sending an access token for a user.
+        // Everything else will be environment setup dependent anyway
+        ValidateActor = false,
         ValidateIssuer = false,
         ValidateIssuerSigningKey = false,
-        RequireExpirationTime = true
+        ValidateLifetime = false,
+        ValidateAudience = false,
+        ValidateTokenReplay = false,
+        RequireSignedTokens = false,
+        SignatureValidator = (token, _) => new JwtSecurityToken(token),
+        
+        RequireExpirationTime = true,
+        RequireAudience = true,
       };
     });
 builder.Services.AddAuthorization(o =>

--- a/DummyControllerApi/Program.cs
+++ b/DummyControllerApi/Program.cs
@@ -1,6 +1,10 @@
+using DummyControllerApi.Config;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+
+builder.Services.Configure<EgressBucketDetailsOptions>(builder.Configuration.GetSection("EgressBucketDetails"));
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/DummyControllerApi/Properties/launchSettings.json
+++ b/DummyControllerApi/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "DummyControllerApi": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7127;http://localhost:5289",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/DummyControllerApi/Services/EgressApprovalHostedService.cs
+++ b/DummyControllerApi/Services/EgressApprovalHostedService.cs
@@ -1,0 +1,6 @@
+namespace DummyControllerApi.Services;
+
+public class EgressApprovalHostedService
+{
+  
+}

--- a/DummyControllerApi/Services/EgressApprovalHostedService.cs
+++ b/DummyControllerApi/Services/EgressApprovalHostedService.cs
@@ -44,7 +44,7 @@ public class EgressApprovalHostedService : BackgroundService
 
           // TODO in future the egress request should be able to tell Hutch none is required...
 
-          // TODO make an HTTP Request to Hutch
+          // Make an HTTP Request to Hutch for /approval
           var url = Url.Combine(config["HutchApiBaseUrl"], "jobs", subId, "approval");
 
           var details = new HutchApprovalRequestModel
@@ -72,7 +72,7 @@ public class EgressApprovalHostedService : BackgroundService
 
   public override async Task StopAsync(CancellationToken stoppingToken)
   {
-    _logger.LogInformation("Stopping polling WorkflowJob Action Queue");
+    _logger.LogInformation("Stopping EgressApproval Queue Handler");
 
     await base.StopAsync(stoppingToken);
   }

--- a/DummyControllerApi/Services/EgressApprovalHostedService.cs
+++ b/DummyControllerApi/Services/EgressApprovalHostedService.cs
@@ -1,6 +1,70 @@
+using System.Text.Json;
+using DummyControllerApi.Models;
+using Flurl;
+using Flurl.Http;
+using Microsoft.Extensions.Options;
+
 namespace DummyControllerApi.Services;
 
-public class EgressApprovalHostedService
+public class EgressApprovalHostedService : BackgroundService
 {
-  
+  private readonly ILogger<EgressApprovalHostedService> _logger;
+  private readonly IServiceProvider _serviceProvider;
+
+  public EgressApprovalHostedService(
+    ILogger<EgressApprovalHostedService> logger,
+    IServiceProvider serviceProvider)
+  {
+    _logger = logger;
+    _serviceProvider = serviceProvider;
+  }
+
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    while (!stoppingToken.IsCancellationRequested)
+    {
+      try
+      {
+        // Every 5 seconds (unless we're busy) we poll the in memory queue for unprocessed approvals
+        var delay = Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+
+        using var scope = _serviceProvider.CreateScope();
+
+        var queue = _serviceProvider.GetRequiredService<InMemoryApprovalQueue>();
+        var config = _serviceProvider.GetRequiredService<IConfiguration>();
+
+        if (queue.HasItems())
+        {
+          var subId = queue.Dequeue();
+          
+          // delay 5 seconds after picking it up to ensure Hutch is ready and to "pretend" to approve stuff
+          await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+          
+          // TODO in future the egress request should be able to tell Hutch none is required...
+
+          // TODO make an HTTP Request to Hutch
+          var url = Url.Combine(config["HutchApiBaseUrl"], "jobs", subId, "approval");
+
+          await url.PostJsonAsync(new HutchApprovalRequestModel
+          {
+            Files = new() { ["file1"] = true, ["file2"] = true }
+          }, cancellationToken: stoppingToken);
+        }
+
+        await delay;
+      }
+      catch (Exception e) // exceptions shouldn't bring down the whole HostedService
+      {
+        _logger.LogError(e,
+          "EgressApproval threw an Exception while running");
+      }
+    }
+  }
+
+  public override async Task StopAsync(CancellationToken stoppingToken)
+  {
+    _logger.LogInformation("Stopping polling WorkflowJob Action Queue");
+
+    await base.StopAsync(stoppingToken);
+  }
 }

--- a/DummyControllerApi/Services/InMemoryApprovalQueue.cs
+++ b/DummyControllerApi/Services/InMemoryApprovalQueue.cs
@@ -13,4 +13,9 @@ public class InMemoryApprovalQueue
   {
     return _queue.Dequeue();
   }
+
+  public bool HasItems()
+  {
+    return _queue.Count > 0;
+  }
 }

--- a/DummyControllerApi/Services/InMemoryApprovalQueue.cs
+++ b/DummyControllerApi/Services/InMemoryApprovalQueue.cs
@@ -1,0 +1,16 @@
+namespace DummyControllerApi.Services;
+
+public class InMemoryApprovalQueue
+{
+  private readonly Queue<string> _queue = new();
+
+  public void Enqueue(string subId)
+  {
+    _queue.Enqueue(subId);
+  }
+
+  public string Dequeue()
+  {
+    return _queue.Dequeue();
+  }
+}

--- a/DummyControllerApi/appsettings.Development.json
+++ b/DummyControllerApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/DummyControllerApi/appsettings.Development.json
+++ b/DummyControllerApi/appsettings.Development.json
@@ -4,5 +4,7 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+
+  "HutchApiBaseUrl": "http://localhost:5209/api"
 }

--- a/DummyControllerApi/appsettings.json
+++ b/DummyControllerApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/Hutch.sln
+++ b/Hutch.sln
@@ -7,13 +7,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HutchAgent", "app\HutchAgen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HutchAgent.Tests", "app\HutchAgent.Tests\HutchAgent.Tests.csproj", "{6066B321-C00D-4478-8F95-71EEB91BC797}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DummyControllerApi", "DummyControllerApi\DummyControllerApi.csproj", "{D8EB96F0-45C6-4AF1-8743-3E05F77459CC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-    {2D9B3839-B34E-4897-ADF2-96F47A3C401F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+				{2D9B3839-B34E-4897-ADF2-96F47A3C401F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2D9B3839-B34E-4897-ADF2-96F47A3C401F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D9B3839-B34E-4897-ADF2-96F47A3C401F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D9B3839-B34E-4897-ADF2-96F47A3C401F}.Release|Any CPU.Build.0 = Release|Any CPU
@@ -21,6 +23,10 @@ Global
 		{6066B321-C00D-4478-8F95-71EEB91BC797}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6066B321-C00D-4478-8F95-71EEB91BC797}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6066B321-C00D-4478-8F95-71EEB91BC797}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8EB96F0-45C6-4AF1-8743-3E05F77459CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8EB96F0-45C6-4AF1-8743-3E05F77459CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8EB96F0-45C6-4AF1-8743-3E05F77459CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8EB96F0-45C6-4AF1-8743-3E05F77459CC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/app/HutchAgent/Models/ControllerApi/FilesReadyForReviewRequest.cs
+++ b/app/HutchAgent/Models/ControllerApi/FilesReadyForReviewRequest.cs
@@ -2,5 +2,6 @@ namespace HutchAgent.Models.ControllerApi;
 
 public class FilesReadyForReviewRequest
 {
+  public string SubId { get; set; } = string.Empty;
   public List<string> Files { get; set; } = new();
 }

--- a/app/HutchAgent/Services/ControllerApiService.cs
+++ b/app/HutchAgent/Services/ControllerApiService.cs
@@ -61,7 +61,10 @@ public class ControllerApiService
     _logger.LogDebug("Requesting Egress Bucket from {Url}", Url.Combine(_apiOptions.BaseUrl, url));
 
     if (!_identity.IsTokenValid(_accessToken)) await UpdateToken();
-    return await _http.Request(url).GetAsync().ReceiveJson<MinioOptions>()
+    return await _http.Request(url)
+             .WithOAuthBearerToken(_accessToken)
+             .GetAsync()
+             .ReceiveJson<MinioOptions>()
            ?? throw new InvalidOperationException(
              "No Response Body was received for an Egress Bucket request.");
     // TODO attempt refreshing if token rejected?
@@ -85,11 +88,13 @@ public class ControllerApiService
       "Job [{JobId}]: Confirming with TRE Controller API that Egress Outputs have been transferred", jobId);
 
     if (!_identity.IsTokenValid(_accessToken)) await UpdateToken();
-    await _http.Request(url).PostJsonAsync(
-      new FilesReadyForReviewRequest()
-      {
-        Files = files
-      });
+    await _http.Request(url)
+      .WithOAuthBearerToken(_accessToken)
+      .PostJsonAsync(
+        new FilesReadyForReviewRequest()
+        {
+          Files = files
+        });
     // TODO attempt refreshing if token rejected?
   }
 
@@ -114,7 +119,9 @@ public class ControllerApiService
       });
 
     if (!_identity.IsTokenValid(_accessToken)) await UpdateToken();
-    await _http.Request(url).PostAsync();
+    await _http.Request(url)
+      .WithOAuthBearerToken(_accessToken)
+      .PostAsync();
     // TODO attempt refreshing if token rejected?
   }
 }

--- a/app/HutchAgent/Services/ControllerApiService.cs
+++ b/app/HutchAgent/Services/ControllerApiService.cs
@@ -81,8 +81,7 @@ public class ControllerApiService
     if (await _features.IsEnabledAsync(FeatureFlags.StandaloneMode))
       throw new InvalidOperationException(_standaloneModeError);
 
-    var url = "Submission/FilesReadyForReview"
-      .SetQueryParam("subId", jobId);
+    var url = "Submission/FilesReadyForReview";
 
     _logger.LogInformation(
       "Job [{JobId}]: Confirming with TRE Controller API that Egress Outputs have been transferred", jobId);
@@ -93,6 +92,7 @@ public class ControllerApiService
       .PostJsonAsync(
         new FilesReadyForReviewRequest()
         {
+          SubId = jobId,
           Files = files
         });
     // TODO attempt refreshing if token rejected?

--- a/app/HutchAgent/appsettings.Development.json
+++ b/app/HutchAgent/appsettings.Development.json
@@ -9,7 +9,7 @@
     "Secure": false
   },
   "ControllerApi": {
-    "BaseUrl": "http://localhost:5289/api"
+    "BaseUrl": "https://localhost:7127/api"
   },
   "Flags": {
     "StandaloneMode": true

--- a/app/HutchAgent/appsettings.Development.json
+++ b/app/HutchAgent/appsettings.Development.json
@@ -8,6 +8,9 @@
   "StoreDefaults": {
     "Secure": false
   },
+  "ControllerApi": {
+    "BaseUrl": "http://localhost:5289/api"
+  },
   "Flags": {
     "StandaloneMode": true
   }


### PR DESCRIPTION
<!--
     ⚠ Ensure the PR title starts with a reference to the primary Azure Boards work item it completes, in the form `AB#<id> My PR Title`.
     
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     PR Guidance:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡️ Optimization
- [ ] 📝 Documentation Update

## Description

This PR adds a development only "Dummy Controller Api" app that can be used for testing Hutch outside of standalone mode.

It is not even close to a complete TRE Controller API implementation; it only implements the endpoints Hutch interacts with upstream and, for convenience, the downstream call to hutch's `jobs/approval` endpoint.

It requires token auth (to aid testing) but does no validation of provided tokens, to eliminate the need for a full oidc configuration.

It does some basic request validation, but otherwise its only job is to get the endpoint interfaces and response payloads correct to keep Hutch happy.

It keeps no persistent state and so doesn't care about accurate submission id's.

Hutch must be configured for OIDC so that it can get tokens for use in Controller API calls.

It allows for the following workflow to be completed in Hutch not in standalone mode:

- Submit job directly to Hutch API
- Hutch will send status updates throughout to Dummy Controller API for that job id
- Hutch will execute the job if valid
- After execution Hutch will request egress details from Dummy Controller API
  - Dummy Controller API provides preconfigured details only, not anything per-job.
- Hutch will upload outputs and inform Dummy Controller API that files are ready for review
- Dummy Controller API will accept the `FilesReadyForReview` request, wait about 10 seconds and then hit Hutch's approval endpoint for the same job with a "FullyApproved" status
- Hutch will then perform job finalisation, following the successful approval

This PR also fixes some elements of the above workflow in HutchAgent, discovered after having the dummy API to test against.

Notably:
- Added OIDC Tokens to Controller API calls (we fetched the tokens before and never used them)
- FilesReadyForReview interface change

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why:
    - Dummy Controller API is a lightweight test service for development only and behaviour expectations may be volatile until later in the project.
- [ ] ❓ I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![testing](https://media.giphy.com/media/B4xdycvhDq7qM3cdh2/giphy.gif)
