### PR TITLE
AB#131740: Workflow Execution skipping

### DIFF
--- a/app/HutchAgent/Config/WorkflowTriggerOptions.cs
+++ b/app/HutchAgent/Config/WorkflowTriggerOptions.cs
@@ -21,6 +21,28 @@ public class WorkflowTriggerOptions
   /// Should container images downloaded for workflows be included in the outputs?
   /// </summary>
   public bool IncludeContainersInOutput { get; set; }
+
+  /// <summary>
+  /// <para>
+  /// If this is a non-empty value, Workflow Execution will be skipped,
+  /// and the file path provided in this value will be used as the output from execution.
+  /// </para>
+  /// <para>
+  /// For example, `/path/to/execution.crate.zip` would cause Hutch to not execute the job's workflow,
+  /// but instead queue an InitiateEgress action to use the zip file in the path as if it was the execution output.
+  /// Note that a zip file is expected, (ideally an RO-Crate for authenticity).
+  /// </para>
+  /// <para>
+  /// Intended for development and testing when actual workflow execution is not needed or desirable,
+  /// but instead the post-execution behaviours can be tested with a static output.
+  /// </para>
+  /// <para>
+  /// Relative paths are relative to Hutch's working directory root
+  /// (<see cref="PathOptions.WorkingDirectoryBase"/>) - not a specific job's.
+  /// </para>
+  /// 
+  /// </summary>
+  public string SkipExecutionUsingOutputFile { get; set; } = string.Empty;
   
   /// <summary>
   /// Don't ask WfExS for a full provenance output crate (i.e. don't use `--full`).

--- a/app/HutchAgent/HutchAgent.csproj
+++ b/app/HutchAgent/HutchAgent.csproj
@@ -36,4 +36,12 @@
     <PackageReference Include="YamlDotNet" Version="13.1.1" />
   </ItemGroup>
 
+<!-- Ensure the contents of `hutch-workdir` is never interpreted as project source files -->
+  <ItemGroup>
+    <Compile Remove="hutch-workdir\**" />
+    <EmbeddedResource Remove="hutch-workdir\**" />
+    <Content Remove="hutch-workdir\**" />
+    <None Remove="hutch-workdir\**" />
+  </ItemGroup>
+
 </Project>

--- a/app/HutchAgent/Models/JobQueue/InitiateEgressPayloadModel.cs
+++ b/app/HutchAgent/Models/JobQueue/InitiateEgressPayloadModel.cs
@@ -1,0 +1,6 @@
+namespace HutchAgent.Models.JobQueue;
+
+public class InitiateEgressPayloadModel
+{
+  public string OutputFile { get; set; } = string.Empty;
+}

--- a/app/HutchAgent/Models/JobQueue/JobQueueMessage.cs
+++ b/app/HutchAgent/Models/JobQueue/JobQueueMessage.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace HutchAgent.Models.JobQueue;
@@ -9,4 +10,9 @@ public class JobQueueMessage
 
   [JsonPropertyName("actionType")]
   public required string ActionType { get; init; }
+
+  /// <summary>
+  /// Optional payload which should be deserializable to an `{ActionType}PayloadModel` if present
+  /// </summary>
+  public string? Payload { get; init; }
 }

--- a/app/HutchAgent/Models/JobQueue/JobQueueMessage.cs
+++ b/app/HutchAgent/Models/JobQueue/JobQueueMessage.cs
@@ -3,6 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace HutchAgent.Models.JobQueue;
 
+// for some unknown reason, these *need* JsonPropertyName attributes to work
+// when serializing/deserializing with the queue?
 public class JobQueueMessage
 {
   [JsonPropertyName("jobId")]
@@ -14,5 +16,6 @@ public class JobQueueMessage
   /// <summary>
   /// Optional payload which should be deserializable to an `{ActionType}PayloadModel` if present
   /// </summary>
-  public string? Payload { get; init; }
+  [JsonPropertyName("payload")]
+  public string? Payload { get; set; }
 }

--- a/app/HutchAgent/Services/ActionHandlers/ExecuteActionHandler.cs
+++ b/app/HutchAgent/Services/ActionHandlers/ExecuteActionHandler.cs
@@ -9,6 +9,7 @@ namespace HutchAgent.Services.ActionHandlers;
 
 public class ExecuteActionHandler : IActionHandler
 {
+  private readonly ILogger<ExecuteActionHandler> _logger;
   private readonly WorkflowFetchService _workflowFetchService;
   private readonly WorkflowTriggerService _workflowTriggerService;
   private readonly WorkflowJobService _workflowJobService;
@@ -19,6 +20,7 @@ public class ExecuteActionHandler : IActionHandler
   private readonly StatusReportingService _status;
 
   public ExecuteActionHandler(
+    ILogger<ExecuteActionHandler> logger,
     WorkflowFetchService workflowFetchService,
     WorkflowTriggerService workflowTriggerService,
     WorkflowJobService workflowJobService,
@@ -28,6 +30,7 @@ public class ExecuteActionHandler : IActionHandler
     StatusReportingService status,
     IOptions<WorkflowTriggerOptions> workflowOptions)
   {
+    _logger = logger;
     _workflowFetchService = workflowFetchService;
     _workflowTriggerService = workflowTriggerService;
     _workflowJobService = workflowJobService;
@@ -59,6 +62,13 @@ public class ExecuteActionHandler : IActionHandler
     // Execute workflow.
     if (string.IsNullOrWhiteSpace(_workflowOptions.SkipExecutionUsingOutputFile))
       await _workflowTriggerService.TriggerWfexs(job, roCrate);
+    else
+    {
+      _logger.LogInformation(
+        "Job [{JobId}] Skipping Execution to use configured output file: {OutputFile}",
+        jobId,
+        _workflowOptions.SkipExecutionUsingOutputFile);
+    }
 
     // Queue Egress Initiation
     var queueMessage = new JobQueueMessage

--- a/app/HutchAgent/Services/ActionHandlers/ExecuteActionHandler.cs
+++ b/app/HutchAgent/Services/ActionHandlers/ExecuteActionHandler.cs
@@ -38,7 +38,7 @@ public class ExecuteActionHandler : IActionHandler
     _workflowOptions = workflowOptions.Value;
   }
 
-  public async Task HandleAction(string jobId)
+  public async Task HandleAction(string jobId, object? payload)
   {
     // Get job.
     var job = await _workflowJobService.Get(jobId);

--- a/app/HutchAgent/Services/ActionHandlers/FetchAndExecuteActionHandler.cs
+++ b/app/HutchAgent/Services/ActionHandlers/FetchAndExecuteActionHandler.cs
@@ -35,7 +35,7 @@ public class FetchAndExecuteActionHandler : IActionHandler
     _features = features;
   }
 
-  public async Task HandleAction(string jobId)
+  public async Task HandleAction(string jobId, object? payload)
   {
     try
     {
@@ -92,7 +92,7 @@ public class FetchAndExecuteActionHandler : IActionHandler
       }
 
       // Execute
-      await _executeHandler.HandleAction(jobId);
+      await _executeHandler.HandleAction(jobId, null);
     }
     catch (KeyNotFoundException e)
     {

--- a/app/HutchAgent/Services/ActionHandlers/FinalizeActionHandler.cs
+++ b/app/HutchAgent/Services/ActionHandlers/FinalizeActionHandler.cs
@@ -44,6 +44,7 @@ public class FinalizeActionHandler : IActionHandler
     var job = await _jobs.Get(jobId);
 
     // TODO Should we be checking if the job is actually ready instead of assuming it can only be queued if it is?!
+    // yes - at minimum check that the disclosure check assessaction is complete
 
     // 1. Copy approved outputs to the working crate
     FilesystemUtility.CopyDirectory(

--- a/app/HutchAgent/Services/ActionHandlers/FinalizeActionHandler.cs
+++ b/app/HutchAgent/Services/ActionHandlers/FinalizeActionHandler.cs
@@ -39,7 +39,7 @@ public class FinalizeActionHandler : IActionHandler
     _status = status;
   }
 
-  public async Task HandleAction(string jobId)
+  public async Task HandleAction(string jobId, object? payload)
   {
     var job = await _jobs.Get(jobId);
 

--- a/app/HutchAgent/Services/ActionHandlers/InitiateEgressActionHandler.cs
+++ b/app/HutchAgent/Services/ActionHandlers/InitiateEgressActionHandler.cs
@@ -58,6 +58,13 @@ public class InitiateEgressActionHandler : IActionHandler
     _logger.LogInformation("Checking job status for job: {JobId}", jobId);
     var job = await _jobs.Get(jobId);
 
+    if (!string.IsNullOrWhiteSpace(payload?.OutputFile))
+    {
+      _logger.LogInformation(
+        "Job [{JobId}] OutputFile specified - Execution was skipped and Egress will be performed using the file at {OutputPath}",
+        jobId,
+        payload.OutputFile);
+    }
 
     var completionResult = string.IsNullOrWhiteSpace(payload?.OutputFile)
       ? await _workflow.HasCompleted(job.ExecutorRunId)
@@ -86,10 +93,19 @@ public class InitiateEgressActionHandler : IActionHandler
     await _status.ReportStatus(job.Id, JobStatus.PreparingOutputs);
 
     // Unpack outputs from the appropriate source
-    if(!string.IsNullOrWhiteSpace(payload?.OutputFile))
+    if (!string.IsNullOrWhiteSpace(payload?.OutputFile))
+    {
+      _logger.LogInformation("Job [{JobId}] Unpacking outputs directly from {OutputPath}", jobId, payload.OutputFile);
       _workflow.UnpackOutputsFromPath(payload.OutputFile, job.WorkingDirectory.JobEgressOutputs());
+    }
     else
+    {
+      _logger.LogInformation(
+        "Job [{JobId}] Unpacking outputs from Executor Run [{RunId}] working directory",
+        jobId,
+        job.ExecutorRunId);
       _workflow.UnpackOutputs(job.ExecutorRunId, job.WorkingDirectory.JobEgressOutputs());
+    }
 
     // 3. Get target bucket for egress checks
     var useDefaultStore = await _features.IsEnabledAsync(FeatureFlags.StandaloneMode);

--- a/app/HutchAgent/Services/ActionHandlers/InitiateEgressActionHandler.cs
+++ b/app/HutchAgent/Services/ActionHandlers/InitiateEgressActionHandler.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using HutchAgent.Config;
 using HutchAgent.Constants;
 using HutchAgent.Models.JobQueue;
+using HutchAgent.Results;
 using HutchAgent.Services.Contracts;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
@@ -49,13 +50,25 @@ public class InitiateEgressActionHandler : IActionHandler
     _queueOptions = queueOptions.Value;
   }
 
-  public async Task HandleAction(string jobId, object? payload)
+  public async Task HandleAction(string jobId, object? payloadObject)
   {
+    var payload = (InitiateEgressPayloadModel?)payloadObject;
+
     // 1. Check if job ready
     _logger.LogInformation("Checking job status for job: {JobId}", jobId);
     var job = await _jobs.Get(jobId);
-    
-    var completionResult = await _workflow.HasCompleted(job.ExecutorRunId);
+
+
+    var completionResult = string.IsNullOrWhiteSpace(payload?.OutputFile)
+      ? await _workflow.HasCompleted(job.ExecutorRunId)
+      // if we have an output file, we skipped execution, so falsify the completion
+      : new WorkflowCompletionResult
+      {
+        IsComplete = true,
+        ExitCode = 0,
+        StartTime = DateTimeOffset.UtcNow - TimeSpan.FromMinutes(1),
+        EndTime = DateTimeOffset.UtcNow
+      };
 
     if (!completionResult.IsComplete) // not ready; re-queue to check again later
     {
@@ -72,7 +85,11 @@ public class InitiateEgressActionHandler : IActionHandler
     // 2. Prepare outputs for egress checks
     await _status.ReportStatus(job.Id, JobStatus.PreparingOutputs);
 
-    _workflow.UnpackOutputs(job.ExecutorRunId, job.WorkingDirectory.JobEgressOutputs());
+    // Unpack outputs from the appropriate source
+    if(!string.IsNullOrWhiteSpace(payload?.OutputFile))
+      _workflow.UnpackOutputsFromPath(payload.OutputFile, job.WorkingDirectory.JobEgressOutputs());
+    else
+      _workflow.UnpackOutputs(job.ExecutorRunId, job.WorkingDirectory.JobEgressOutputs());
 
     // 3. Get target bucket for egress checks
     var useDefaultStore = await _features.IsEnabledAsync(FeatureFlags.StandaloneMode);
@@ -87,7 +104,7 @@ public class InitiateEgressActionHandler : IActionHandler
     await _jobs.Set(job);
 
     _logger.LogInformation("job [{JobId}] Egress Target: {Target}", job.Id, job.EgressTarget);
-    
+
     await _status.ReportStatus(job.Id, JobStatus.DataOutRequested);
 
     // 4. Upload files to bucket

--- a/app/HutchAgent/Services/ActionHandlers/InitiateEgressActionHandler.cs
+++ b/app/HutchAgent/Services/ActionHandlers/InitiateEgressActionHandler.cs
@@ -49,12 +49,12 @@ public class InitiateEgressActionHandler : IActionHandler
     _queueOptions = queueOptions.Value;
   }
 
-  public async Task HandleAction(string jobId)
+  public async Task HandleAction(string jobId, object? payload)
   {
     // 1. Check if job ready
     _logger.LogInformation("Checking job status for job: {JobId}", jobId);
     var job = await _jobs.Get(jobId);
-
+    
     var completionResult = await _workflow.HasCompleted(job.ExecutorRunId);
 
     if (!completionResult.IsComplete) // not ready; re-queue to check again later

--- a/app/HutchAgent/Services/Contracts/IActionHandler.cs
+++ b/app/HutchAgent/Services/Contracts/IActionHandler.cs
@@ -2,5 +2,5 @@ namespace HutchAgent.Services.Contracts;
 
 public interface IActionHandler
 {
-  public Task HandleAction(string jobId);
+  public Task HandleAction(string jobId, object? payload);
 }

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -95,6 +95,18 @@ public class WorkflowTriggerService
     return result;
   }
 
+  public void UnpackOutputsFromPath(string sourcePath, string targetPath)
+  {
+    if (!Directory.Exists(targetPath))
+      Directory.CreateDirectory(targetPath);
+
+    ZipFile.ExtractToDirectory(sourcePath, targetPath);
+
+
+    // Path to workflow containers // TODO retain metadata; delete images only!
+    var containersPath = Path.Combine(targetPath, "containers");
+    if (!_workflowOptions.IncludeContainersInOutput) Directory.Delete(containersPath, recursive: true);
+  }
   public void UnpackOutputs(string executorRunId, string targetPath)
   {
     // Path the to the job outputs
@@ -104,15 +116,7 @@ public class WorkflowTriggerService
       "outputs",
       "execution.crate.zip");
 
-    if (!Directory.Exists(targetPath))
-      Directory.CreateDirectory(targetPath);
-
-    ZipFile.ExtractToDirectory(executionCratePath, targetPath);
-
-
-    // Path to workflow containers
-    var containersPath = Path.Combine(targetPath, "containers");
-    if (_workflowOptions.IncludeContainersInOutput) Directory.Delete(containersPath, recursive: true);
+    UnpackOutputsFromPath(executionCratePath, targetPath);
   }
 
   /// <summary>

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -30,17 +30,21 @@ public class WorkflowTriggerService
   private readonly IDeserializer _unyaml;
   private readonly StatusReportingService _status;
   private readonly WorkflowJobService _jobs;
+  private readonly PathOptions _paths;
 
   public WorkflowTriggerService(
     IOptions<WorkflowTriggerOptions> workflowOptions,
     ILogger<WorkflowTriggerService> logger,
     FiveSafesCrateService crateService,
-    StatusReportingService status, WorkflowJobService jobs)
+    StatusReportingService status,
+    WorkflowJobService jobs,
+    IOptions<PathOptions> paths)
   {
     _logger = logger;
     _crateService = crateService;
     _status = status;
     _jobs = jobs;
+    _paths = paths.Value;
     _workflowOptions = workflowOptions.Value;
     _activateVenv = "source " + _workflowOptions.VirtualEnvironmentPath;
     _unyaml = new DeserializerBuilder()
@@ -100,13 +104,19 @@ public class WorkflowTriggerService
     if (!Directory.Exists(targetPath))
       Directory.CreateDirectory(targetPath);
 
+    // Relative paths should be relative to Hutch working directory
+    if (!Path.IsPathFullyQualified(sourcePath))
+      sourcePath = Path.Combine(_paths.WorkingDirectoryBase, sourcePath);
+    
     ZipFile.ExtractToDirectory(sourcePath, targetPath);
 
 
     // Path to workflow containers // TODO retain metadata; delete images only!
     var containersPath = Path.Combine(targetPath, "containers");
-    if (!_workflowOptions.IncludeContainersInOutput) Directory.Delete(containersPath, recursive: true);
+    if (!_workflowOptions.IncludeContainersInOutput)
+      Directory.Delete(containersPath, recursive: true);
   }
+  
   public void UnpackOutputs(string executorRunId, string targetPath)
   {
     // Path the to the job outputs

--- a/website/docs/development/partial-running.md
+++ b/website/docs/development/partial-running.md
@@ -1,0 +1,61 @@
+It's possible to run Hutch with only partial engagement with the external services it interacts with.
+
+This document provides notes around how to configure Hutch to skip certain external interactions, which can simplify development setup and actually developing and testing certain areas of the application.
+
+Obviously features should be fully tested with all external services before being considered complete and working, but omitting some interactions can significantly quicken the internal developer loop.
+
+## Dummy Controller API
+
+Hutch provides a dummy implementation of the TRE Controller API which is interface compliant with only the parts of the TRE Controller that Hutch interacts with.
+
+You can run this in development as a substitute for a real Controller API implementation, but it still requires OIDC config.
+
+## Standalone Mode
+
+Standalone mode forces Hutch to run without ever interacting with a TRE Controller API (not even the dummy one).
+
+This means you don't need a TRE Controller API.
+
+It also means (depending on your Intermediary Store config) that you may not need OIDC config (and therefore not need an Identity Provider like Keycloak). See [below](#intermediary-store-without-oidc) 
+
+In Standalone mode, Hutch does the following things:
+
+- Status Updates only log to local logging targets - no HTTP requests are made
+- InitiateEgress will not make an HTTP request for Egress Bucket Details; instead it will substitute the locally configured details in "StoreDefaults"
+- InitiateEgress will not make an HTTP request for `FilesReadyForReview` when it has uploaded outputs to the Egress Bucket.
+  - it will log when output uploading is complete, and advise you to make an approval request manually
+- It will not make a `FinalOutcome` HTTP Request once packaging and upload of the final results crate is complete
+
+Changes to interacting with Hutch are therefore as follows:
+
+- You must manually submit jobs to the `/jobs` endpoint
+- You must manually approve egress at the `/jobs/{id}/approval` endpoint
+
+## Intermediary Store without OIDC
+
+In the full TRE-FX stack, the expectation is that Hutch will interact with an OIDC Identity Provider to get tokens, and those tokens will be used in two places:
+
+- all TRE Controller API requests
+- to get temporary credentials for Intermediary Store API requests
+
+It is however possible to use the Intermediary Store without OIDC.
+
+If Hutch's "StoreDefaults" contain an `accessKey` and `secretKey` these can be used instead of using an OIDC token to get temporary ones.
+
+Also for job submissions, the `crateSource` can include an `accessKey` and `secretKey` to be used directly.
+
+If Hutch is also in Standalone Mode, then OIDC is not required at all, and Hutch's OIDC configuration can be omitted, and the OIDC service (e.g. Keycloak in the development `docker-compose`) need not be run or configured.
+
+## Skip Workflow Execution
+
+When Hutch receives a job, it fetches a referenced workflow for the job and executes it, the handles returning the outputs to the job's source via the Intermediary Store.
+
+However this requires environment setup of the actual Workflow Executor (e.g. Wfexs), and workflow staging and execution can be quite slow.
+
+It is possible to skip execution altogether (but retain the integrity of the rest of the job lifecycle - before and after execution), which can be useful when developing or testing post-execution behaviours.
+
+To do this, you'll need a suitable zip file to act as the outputs from the execution that never happened. Hutch will then substitute this output file at the correct point in the lifecycle, and carry on as if everything was normal.
+
+It's recommended to use a real execution output if possible - even better if it's for the input job's workflow, to at least appear to be authentic.
+
+Set the setting `WorkflowExecutor:SkipExecutionWithOutputFile` to a non-empty value, which should be the path to your dummy output zip. Absolute paths are fine; relative paths are relative to the working directory root for Hutch as defined in the setting `Paths:WorkingDirectoryBase`. It's intended for this file to be used statically across multiple job runs, so it's not a per-job path.

--- a/website/docs/development/partial-running.md
+++ b/website/docs/development/partial-running.md
@@ -48,7 +48,7 @@ If Hutch is also in Standalone Mode, then OIDC is not required at all, and Hutch
 
 ## Skip Workflow Execution
 
-When Hutch receives a job, it fetches a referenced workflow for the job and executes it, the handles returning the outputs to the job's source via the Intermediary Store.
+Normally, when Hutch receives a job, it fetches a referenced workflow for the job and executes it, then handles returning the outputs to the job's source via the Intermediary Store.
 
 However this requires environment setup of the actual Workflow Executor (e.g. Wfexs), and workflow staging and execution can be quite slow.
 
@@ -58,4 +58,4 @@ To do this, you'll need a suitable zip file to act as the outputs from the execu
 
 It's recommended to use a real execution output if possible - even better if it's for the input job's workflow, to at least appear to be authentic.
 
-Set the setting `WorkflowExecutor:SkipExecutionWithOutputFile` to a non-empty value, which should be the path to your dummy output zip. Absolute paths are fine; relative paths are relative to the working directory root for Hutch as defined in the setting `Paths:WorkingDirectoryBase`. It's intended for this file to be used statically across multiple job runs, so it's not a per-job path.
+Set the setting `WorkflowExecutor:SkipExecutionUsingOutputFile` to a non-empty value, which should be the path to your dummy output zip. Absolute paths are fine; relative paths are relative to the working directory root for Hutch as defined in the setting `Paths:WorkingDirectoryBase`. It's intended for this file to be used statically across multiple job runs, so it's not a per-job path.

--- a/website/docs/getting-started/configuration/agent.md
+++ b/website/docs/getting-started/configuration/agent.md
@@ -87,6 +87,10 @@ Hutch can be configured using the following source in [the usual .NET way](https
 
     // The below are more for development / debugging
 
+    // If a path is provided, Hutch will skip Workflow Execution altogether
+    // and instead use the zip file from this path as if it were the execution output
+    "SkipExecutionUsingOutputFile": "path/to/exection.crate.zip",
+
     // Really we always want a full crate, but some wfexs configs
     // particularly with certain container engines
     // are unreliable with `--full`` on or off, so it can be configured for testing.


### PR DESCRIPTION
<!--
     ⚠ Ensure the PR title starts with a reference to the primary Azure Boards work item it completes, in the form `AB#<id> My PR Title`.
     
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     PR Guidance:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡️ Optimization
- [x] 📝 Documentation Update

## Description

This PR primarily adds the ability to skip workflow execution and substitute a static output crate from a path on disk.

This can be incredibly useful in dev/test when working on areas of Hutch that do not depend on a genuine execution itself, but require an output (e.g. lots of post-execution functionality).

Also documented some of the ways in which Hutch can be run and tested without the full stack present and configured.

Also accidentally fixed container deletion in outputs.

## Related Tickets & Documents

- AB#130929 - output container deletion

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why:
    - Not adding unit testable code
- [ ] ❓ I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![no execution](https://media.giphy.com/media/26vIf8EBu53ZQYVgY/giphy.gif)
