### PR TITLE
AB#131017: Terminology updates

### DIFF
--- a/app/HutchAgent/Models/SubmitJobModel.cs
+++ b/app/HutchAgent/Models/SubmitJobModel.cs
@@ -5,12 +5,12 @@ namespace HutchAgent.Models;
 public class SubmitJobModel
 {
   /// <summary>
-  /// This is a Job ID as provided by the TRE Agent.
+  /// This is a Submission ID as provided by the TRE Controller.
   /// Hutch continues to use it to identify the job internally,
-  /// but also to interact with the TRE Agent in future.
+  /// but also to interact with the TRE Controller API in future.
   /// </summary>
   [Required]
-  public string JobId { get; set; } = string.Empty;
+  public string SubId { get; set; } = string.Empty;
 
   /// <summary>
   /// Optional Project Database Connection details.

--- a/website/docs/development/index.md
+++ b/website/docs/development/index.md
@@ -12,6 +12,12 @@ Here's how to run a local development stack, and guidance on developing differen
 1. A **RabbitMQ** instance
 1. A **WfExS** environment (if you need to be actually running workflows)
 
+### Partial Running
+
+It is possible to run Hutch in various "partial" setups, where it does not fully interact with external services but still performs all its functionality for an end to end job run (within the scope of Hutch's responsibilities, i.e. from job submission to Hutch, through to uploading a final results package to the Intermediary Store).
+
+These partial setups are detailed [here](partial-running.md)
+
 ### Optional for running workflows end to end
 
 - **Podman** - typically Hutch will use WfExS with Podman rather than Docker for airgapped environments

--- a/website/docs/development/partial-running.md
+++ b/website/docs/development/partial-running.md
@@ -1,3 +1,5 @@
+# Partial Running
+
 It's possible to run Hutch with only partial engagement with the external services it interacts with.
 
 This document provides notes around how to configure Hutch to skip certain external interactions, which can simplify development setup and actually developing and testing certain areas of the application.
@@ -10,7 +12,11 @@ Hutch provides a dummy implementation of the TRE Controller API which is interfa
 
 You can run this in development as a substitute for a real Controller API implementation, but it still requires OIDC config.
 
-## Standalone Mode
+Since the Dummy Controller API is not a complete implementation, interaction with Hutch differs as follows:
+
+- You must manually submit jobs to the Hutch Agent `/jobs` endpoint
+
+## Standalone Mode
 
 Standalone mode forces Hutch to run without ever interacting with a TRE Controller API (not even the dummy one).
 

--- a/website/docs/external-systems/minio/minio-keycloak.md
+++ b/website/docs/external-systems/minio/minio-keycloak.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 2
+---
+
+# MinIO and Keycloak
+
 You can connect Minio to Keycloak as an additional authentication source.
 
 The `docker-compose` gives an example of this setup.

--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -14,14 +14,14 @@ Hutch is ideal for Trusted Research Environments (TREs) or Secure Data Environme
 
 ## The Architecture of Hutch
 
-Hutch is part of an "application stack" that was defined by the TRE-FX Project. Hutch itself provides an implementation of the "Executing Agent" module of that stack, interacting in a standard with the other modules, and leveraging existing tools to achieve its functionality.
+Hutch is part of an "application stack" that was defined by the TRE-FX Project. Hutch itself provides an implementation of the "Workflow Executor" module of that stack, interacting in a standard with the other modules, and leveraging existing tools to achieve its functionality.
 
 This affords it a great deal of flexibility in terms of how users may want to run it in different setups and enables it to be easily extended to support new formats or functionality.
 
 The main components of the TRE-FX stack are as follows:
 - The Submission Layer
-- The TRE Agent (Hutch interacts with this)
-- The Executing Agent (Hutch fulfills this module)
+- The TRE Controller (Hutch interacts with this)
+- The Workflow Executor (Hutch fulfills this module)
 - An Intermediary Store (Hutch interacts with this)
 
 Additionally, depending on how (or if!) you implement other areas of the stack, and what your needs are regarding "airgapped" environments, you may require your own:
@@ -34,26 +34,26 @@ The submission layer is an interoperable part of the stack which can accept requ
 
 The submission layer aims to reduce or prevent "vendor lock-in" whereby you enable federated activities only with researchers with access to one specific product. This increases the reach of your data in the research community.
 
-### The TRE Agent
+### The TRE Controller
 
-The TRE Agent sits inside the TRE/SDE to verify and approve incoming jobs and facilitate the approval of data egress within existing TRE workflows.
+The TRE Controller sits inside the TRE/SDE to verify and approve incoming jobs and facilitate the approval of data egress within existing TRE workflows.
 It is the only module within the stack that is allowed outside communication (specifically with the Submission Layer) from inside the TRE.
 
-### The Executing Agent (e.g. Hutch)
-The Executing Agent runs workflow jobs passed to it from the TRE Agent. The RO-Crate in the request is unpacked and, in the case of Hutch, executed using WfExS. Upon completion of the job, outputs are placed in the Intermediary Store and the TRE Agent is notified that they are ready to be inspected for data egress approval. If approved, the results are merged back into the original RO-Crate and returned to the Intermediary Store ready for egress.
+### The Workflow Executor (e.g. Hutch)
+The Workflow Executor runs workflow jobs passed to it from the TRE Controller. The RO-Crate in the request is unpacked and, in the case of Hutch, executed using WfExS. Upon completion of the job, outputs are placed in the Intermediary Store and the TRE Controller is notified that they are ready to be inspected for data egress approval. If approved, the results are merged back into the original RO-Crate and returned to the Intermediary Store ready for egress.
 
-### Intermediary Store
+### The Intermediary Store
 
-This store serves as a place to put the crates for job requests, outputs of executions, and final results crates. Essentially any transfer between the TRE Agent and the Executing Agent (Hutch) can be performed via this store.
+This store serves as a place to put the crates for job requests, outputs of executions, and final results crates. Essentially any transfer between the TRE Controller and the Workflow Executor (Hutch) can be performed via this store.
 
 ## Hutch Implementation Specifics
 
-Hutch implements the **Executing Agent** part of the stack, and interacts with the **TRE Agent** and **Intermediary Store**, as well as optional peripheral components.
+Hutch implements the **Workflow Executor** part of the stack, and interacts with the **TRE Controller** and **Intermediary Store**, as well as optional peripheral components.
 
 Hutch itself is a .NET application, running ASP.NET Core to allow it to provide a REST API for certain interactions.
 
 ### Accepting jobs
-**Hutch** expects a **TRE Agent** to POST jobs to a jobs endpoint over HTTPS.
+**Hutch** expects a **TRE Controller** to `POST` jobs to a jobs endpoint over HTTPS.
 
 **Hutch** will verify that incoming jobs meet the **TRE-FX 5 Safes RO-Crate Profile** in the expected state, and if valid will execute the requested workflow.
 
@@ -64,14 +64,14 @@ Hutch itself is a .NET application, running ASP.NET Core to allow it to provide 
 
 **Hutch** executes **CWL** or **Nextflow** workflows using **WfExS**. **WfExS** is an open source python application that supports CWL and Nextflow workflows, and supports running those workflows in Containers via a number of different container engines such as **docker** and **podman**.
 
-**Hutch** uses **WfExS** with **podman** due to its better support for airgapped environments. **Podman** supports fetching Container Images (such as those for tools used by workflows) from local registries inside an airgapped environment.
+**Hutch** typically uses **WfExS** with **podman** due to its better support for airgapped environments. **Podman** supports fetching Container Images (such as those for tools used by workflows) from local registries inside an airgapped environment.
 
 **Hutch**'s documentation uses **Sonatype Nexus** to fill the role of a local airgapped worflow store and container registry, but these can be fulfilled by other tools as desired.
 
 ### Status and Results
-**Hutch** interacts with the **TRE Agent**'s REST API to provide status updates.
+**Hutch** interacts with the **TRE Controller**'s REST API to provide status updates.
 
-**Hutch** provides workflow outputs to the **TRE Agent** via REST API / the **Intermediary Store**, to enable disclosure checking to approve outputs for egress.
+**Hutch** provides workflow outputs to the **TRE Controller** via REST API / the **Intermediary Store**, to enable disclosure checking to approve outputs for egress.
 
-**Hutch** today can use the **AWS S3 API** (e.g. with a **Minio** server), or a mounted filesystem path, as an **Intermediary Store**.
+**Hutch** today can use the **AWS S3 API** (e.g. with a **MinIO** server) as an **Intermediary Store**.
 

--- a/website/docs/getting-started/installation/agent.md
+++ b/website/docs/getting-started/installation/agent.md
@@ -14,12 +14,7 @@ The Hutch Agent is a .NET application written in C#.
 
 Currently, there are no downloadable binaries for the Hutch Agent. To install it locally, clone the [Hutch Repository](https://github.com/HDRUK/hutch). Then in the `app/HutchAgent` directory run the following commands:
 
-- Build program in release mode
-```bash
-dotnet build --configuration Release
-```
-
-- Run the program
+- Build and run the application project
 ```bash
 dotnet run
 ```


### PR DESCRIPTION
<!--
     ⚠ Ensure the PR title starts with a reference to the primary Azure Boards work item it completes, in the form `AB#<id> My PR Title`.
     
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     PR Guidance:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡️ Optimization
- [x] 📝 Documentation Update

## Description

This PR updates some terminology in the docs, particularly around the TRE-FX stack, and also some boundary cases between the TRE Controller language "submission" and the Hutch language "job".

Hutch's `/jobs` submission payload has changed to use the TRE Controller `subId` form rather than `jobId` for consistency.

## Added/updated tests?

- [ ] ✅ Yes
- [ ] ❌ No, and this is why:
    - non functional changes only
- [ ] ❓ I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![boring](https://media.giphy.com/media/RKS1pHGiUUZ2g/giphy.gif)
