### PR TITLE
AB#131799: when containers are deleted from ouputs, we retain metadata files

### DIFF
--- a/app/HutchAgent/HutchAgent.csproj
+++ b/app/HutchAgent/HutchAgent.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.2" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="19.2.69" />
     <PackageReference Include="YamlDotNet" Version="13.1.1" />
   </ItemGroup>
 

--- a/app/HutchAgent/Program.cs
+++ b/app/HutchAgent/Program.cs
@@ -1,3 +1,4 @@
+using System.IO.Abstractions;
 using System.Reflection;
 using Flurl.Http.Configuration;
 using HutchAgent.Config;
@@ -8,6 +9,7 @@ using HutchAgent.Services;
 using HutchAgent.Services.ActionHandlers;
 using HutchAgent.Services.Contracts;
 using HutchAgent.Services.Hosted;
+using HutchAgent.Utilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.FeatureManagement;
 using Microsoft.OpenApi.Models;
@@ -62,7 +64,8 @@ builder.Services.AddSwaggerGen(o =>
 builder.Services
   .AddAutoMapper(typeof(Program).Assembly)
   .AddSingleton<IFlurlClientFactory, PerBaseUrlFlurlClientFactory>()
-  .AddHttpClient(); // We prefer Flurl for most use cases, but IdentityModel has extensions for vanilla HttpClient
+  .AddHttpClient()  // We prefer Flurl for most use cases, but IdentityModel has extensions for vanilla HttpClient
+  .AddTransient<IFileSystem,FileSystem>();
 
 // IOptions
 builder.Services
@@ -88,6 +91,7 @@ builder.Services
 
 // Other Application Services
 builder.Services
+  .AddTransient<FileSystemUtility>()
   .AddTransient<JobLifecycleService>()
   .AddTransient<StatusReportingService>()
   .AddTransient<WorkflowJobService>()

--- a/app/HutchAgent/Services/ActionHandlers/FinalizeActionHandler.cs
+++ b/app/HutchAgent/Services/ActionHandlers/FinalizeActionHandler.cs
@@ -53,7 +53,7 @@ public class FinalizeActionHandler : IActionHandler
     // yes - at minimum check that the disclosure check assessaction is complete
 
     // 1. Copy approved outputs to the working crate
-    FilesystemUtility.CopyDirectory(
+    FileSystemUtility.CopyDirectory(
       job.WorkingDirectory.JobEgressOutputs(),
       Path.Combine(job.WorkingDirectory.JobCrateRoot(), "outputs"),
       recursive: true);

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -104,7 +104,7 @@ public partial class WorkflowTriggerService
   }
 
   [GeneratedRegex(@".*meta\.json$")]
-  private static partial Regex MatchMetadata();
+  private static partial Regex MatchContainerMetadataFiles();
 
   public void UnpackOutputsFromPath(string sourcePath, string targetPath)
   {
@@ -121,7 +121,7 @@ public partial class WorkflowTriggerService
     {
       // Path to workflow containers
       var containersPath = Path.Combine(targetPath, "containers");
-      _fsu.SelectivelyDelete(containersPath, MatchMetadata());
+      _fsu.SelectivelyDelete(containersPath, MatchContainerMetadataFiles());
     }
   }
 

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Globalization;
+using System.IO.Abstractions;
 using System.IO.Compression;
 using System.Text.RegularExpressions;
 using HutchAgent.Config;
@@ -9,6 +9,7 @@ using HutchAgent.Constants;
 using HutchAgent.Models;
 using HutchAgent.Models.Wfexs;
 using HutchAgent.Results;
+using HutchAgent.Utilities;
 using Microsoft.Extensions.Options;
 using ROCrates;
 using ROCrates.Models;
@@ -20,7 +21,7 @@ namespace HutchAgent.Services;
 
 // TODO this is all pretty wfexs specific;
 // maybe in future could be abstracted into a wfexs implementation of a more general interface?
-public class WorkflowTriggerService
+public partial class WorkflowTriggerService
 {
   private readonly WorkflowTriggerOptions _workflowOptions;
   private readonly ILogger<WorkflowTriggerService> _logger;
@@ -31,6 +32,7 @@ public class WorkflowTriggerService
   private readonly StatusReportingService _status;
   private readonly WorkflowJobService _jobs;
   private readonly PathOptions _paths;
+  private readonly FileSystemUtility _fsu;
 
   public WorkflowTriggerService(
     IOptions<WorkflowTriggerOptions> workflowOptions,
@@ -38,12 +40,14 @@ public class WorkflowTriggerService
     FiveSafesCrateService crateService,
     StatusReportingService status,
     WorkflowJobService jobs,
-    IOptions<PathOptions> paths)
+    IOptions<PathOptions> paths,
+    FileSystemUtility fsu)
   {
     _logger = logger;
     _crateService = crateService;
     _status = status;
     _jobs = jobs;
+    _fsu = fsu;
     _paths = paths.Value;
     _workflowOptions = workflowOptions.Value;
     _activateVenv = "source " + _workflowOptions.VirtualEnvironmentPath;
@@ -99,6 +103,9 @@ public class WorkflowTriggerService
     return result;
   }
 
+  [GeneratedRegex(@".*meta\.json$")]
+  private static partial Regex MatchMetadata();
+
   public void UnpackOutputsFromPath(string sourcePath, string targetPath)
   {
     if (!Directory.Exists(targetPath))
@@ -110,16 +117,11 @@ public class WorkflowTriggerService
 
     ZipFile.ExtractToDirectory(sourcePath, targetPath);
 
-
-    // Path to workflow containers
-    var containersPath = Path.Combine(targetPath, "containers");
     if (!_workflowOptions.IncludeContainersInOutput)
     {
-      foreach (var filePath in Directory.EnumerateFiles(containersPath))
-      {
-        if (!filePath.EndsWith("meta.json")) // retain small metadata files :)
-          File.Delete(filePath);
-      }
+      // Path to workflow containers
+      var containersPath = Path.Combine(targetPath, "containers");
+      _fsu.SelectivelyDelete(containersPath, MatchMetadata());
     }
   }
 
@@ -194,7 +196,7 @@ public class WorkflowTriggerService
             await _jobs.Set(job);
           }
         }
-        
+
         _logger.LogDebug(message, job.Id, job.ExecutorRunId, "StdOut",
           args.Data ?? "event received but data was null");
       };
@@ -461,13 +463,13 @@ public class WorkflowTriggerService
     return absolutePath;
   }
 
+  [GeneratedRegex(
+    @".*-\sInstance\s([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}).*")]
+  private static partial Regex WfexsRunIdLogLine();
+
   private string? FindRunName(string text)
   {
-    var pattern =
-      @".*-\sInstance\s([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}).*";
-    var regex = new Regex(pattern);
-
-    var match = regex.Match(text);
+    var match = WfexsRunIdLogLine().Match(text);
     if (!match.Success)
     {
       _logger.LogError("Didn't match the pattern!");

--- a/app/HutchAgent/Services/WorkflowTriggerService.cs
+++ b/app/HutchAgent/Services/WorkflowTriggerService.cs
@@ -107,16 +107,22 @@ public class WorkflowTriggerService
     // Relative paths should be relative to Hutch working directory
     if (!Path.IsPathFullyQualified(sourcePath))
       sourcePath = Path.Combine(_paths.WorkingDirectoryBase, sourcePath);
-    
+
     ZipFile.ExtractToDirectory(sourcePath, targetPath);
 
 
-    // Path to workflow containers // TODO retain metadata; delete images only!
+    // Path to workflow containers
     var containersPath = Path.Combine(targetPath, "containers");
     if (!_workflowOptions.IncludeContainersInOutput)
-      Directory.Delete(containersPath, recursive: true);
+    {
+      foreach (var filePath in Directory.EnumerateFiles(containersPath))
+      {
+        if (!filePath.EndsWith("meta.json")) // retain small metadata files :)
+          File.Delete(filePath);
+      }
+    }
   }
-  
+
   public void UnpackOutputs(string executorRunId, string targetPath)
   {
     // Path the to the job outputs

--- a/app/HutchAgent/Utilities/FileSystemUtility.cs
+++ b/app/HutchAgent/Utilities/FileSystemUtility.cs
@@ -1,9 +1,33 @@
 using System.IO;
+using System.IO.Abstractions;
+using System.Text.RegularExpressions;
 
 namespace HutchAgent.Utilities;
 
-public static class FilesystemUtility
+public class FileSystemUtility
 {
+  private readonly IFileSystem _fs;
+
+  public FileSystemUtility(IFileSystem fs)
+  {
+    _fs = fs;
+  }
+
+  /// <summary>
+  /// Delete everything from a directory (non-recursive)
+  /// EXCEPT files which match a provided pattern.
+  /// </summary>
+  /// <param name="targetPath">Path to the directory to delete files from</param>
+  /// <param name="keepPattern">A regex pattern for file paths to keep</param>
+  public void SelectivelyDelete(string targetPath, Regex keepPattern)
+  {
+    foreach (var filePath in _fs.Directory.EnumerateFiles(targetPath))
+    {
+      if (!keepPattern.IsMatch(filePath))
+        _fs.File.Delete(filePath);
+    }
+  }
+
   // https://learn.microsoft.com/en-us/dotnet/standard/io/how-to-copy-directories
   /// <summary>
   /// Copy a directory, optionally including all subdirectories recursively.

--- a/test/HutchAgent.Tests/FileSystemUtilityTests/TestSelectivelyDelete.cs
+++ b/test/HutchAgent.Tests/FileSystemUtilityTests/TestSelectivelyDelete.cs
@@ -1,0 +1,39 @@
+using System.IO.Abstractions.TestingHelpers;
+using System.Text.RegularExpressions;
+using HutchAgent.Config;
+using HutchAgent.Services;
+using HutchAgent.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Serilog.Core;
+
+namespace HutchAgent.Tests.WorkflowTriggerServiceTests;
+
+public class TestSelectivelyDelete
+{
+  private readonly Mock<ILogger<MinioStoreService>> _logger = new();
+
+  [Fact]
+  public async void SelectivelyDelete_DeletesNonMatchingFiles()
+  {
+    // Arrange
+    // TODO dummy fs
+    var fs = new MockFileSystem(new Dictionary<string, MockFileData>()
+    {
+      { "/var/somefile.txt", new MockFileData("") },
+      { "/var/somefile-meta.json", new MockFileData("") },
+      { "/var/someotherfile.img", new MockFileData("") }
+    });
+
+    var sut = new FileSystemUtility(fs);
+
+    // Act
+    sut.SelectivelyDelete("/var", new Regex(@".*meta\.json$"));
+
+    // Assert
+    var files = fs.Directory.EnumerateFiles("var").ToList();
+    Assert.Single(files);
+    Assert.Equal("/var/somefile-meta.json", files.Single());
+  }
+}

--- a/test/HutchAgent.Tests/HutchAgent.Tests.csproj
+++ b/test/HutchAgent.Tests/HutchAgent.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="19.2.69" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!--
     ⚠ Ensure the PR title starts with a reference to the primary Azure Boards work item it completes, in the form `AB#<id> My PR Title`.
     
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     PR Guidance:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] ⚡️ Optimization
- [ ] 📝 Documentation Update

## Description

This PR changes output container deletion so that we only delete the images but retain metadata.

## Added/updated tests?

- [x] ✅ Yes
- [ ] ❌ No, and this is why:
- [ ] ❓ I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![yawn](https://media.giphy.com/media/2fbgqwZL9YSJO/giphy.gif)
